### PR TITLE
Add output variable so workflows can detect linter problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,44 @@ There are currently some limitations as to how this action (or any other action)
 
 For details and comments, please refer to [#13](https://github.com/wearerequired/lint-action/issues/13).
 
+
+## Outputs
+
+You can use these outputs to trigger other Actions in your Workflow run based on the result of `lint-action`.
+
+- `problems_detected`: Returns "true" if one or more linters fail OR if autofix pushed a code change to the pull request.
+
+### Example
+
+This example demonstrate a scenario where Black is being used to enforce code style. If Black reformats any of your code
+it will create a commit and push it back to your repository. This example shows providing a personal access token on
+the checkout so that the commit is processed as that user ... which means that Github Action will trigger a new event
+and workflow. After running Black, we check the value of `problems_detected` to know whether or not to end this
+workflow since a new one will have been triggered by the push of the code change.
+
+**Note:** if you do not provide an access token for the checkout step, then the push will NOT trigger a new workflow.
+
+
+```yaml
+    - uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.BOT_TOKEN }}
+
+    - name: Check Code Style with Black
+      id: black
+      uses: wearerequired/lint-action@v1
+      with:
+        github_token: ${{ secrets.github_token }}
+        black: true
+        auto_fix: true
+        black_args: "--line-length 100"
+
+    - name: "Stop workflow for code style changes"
+      if: steps.black.outputs.problems_detected == 'true'
+      run: echo "Code style problems detected ... ending workflow." && exit 1
+```
+
+
 ## Related
 
 - [Electron Builder Action](https://github.com/samuelmeuli/action-electron-builder) – GitHub Action for building and releasing Electron apps

--- a/action.yml
+++ b/action.yml
@@ -343,6 +343,10 @@ inputs:
     required: false
     default: ""
 
+outputs:
+  problems_detected:
+    description: Value is "true", if any linters fail or make code changes. Value is otherwise "false".
+
 runs:
   using: node12
   main: ./src/index.js


### PR DESCRIPTION
This adds an output variable named `problems_detected` that will be set to `true` if one or more of the linters find problems OR if an `autofix` event creates and pushes a code change back to the pull request. The README.md was also updated to document this variable and provide an example of its usage. This would close issue #60 