### PR TITLE
Attach commit annotation to the correct commit for non-pull-requests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,9 +23,10 @@ async function runAction() {
 	const gitEmail = getInput("git_email", true);
 	const commitMessage = getInput("commit_message", true);
 	const checkName = getInput("check_name", true);
+	const isPullRequest = context.eventName === "pull_request";
 
 	// If on a PR from fork: Display messages regarding action limitations
-	if (context.eventName === "pull_request" && context.repository.hasFork) {
+	if (isPullRequest && context.repository.hasFork) {
 		log(
 			"This action does not have permission to create annotations on forks. You may want to run it only on `push` events. See https://github.com/wearerequired/lint-action/issues/13 for details",
 			"error",
@@ -42,7 +43,7 @@ async function runAction() {
 		// Set Git committer username and password
 		git.setUserInfo(gitName, gitEmail);
 	}
-	if (context.eventName === "pull_request") {
+	if (isPullRequest) {
 		// Fetch and check out PR branch:
 		// - "push" event: Already on correct branch
 		// - "pull_request" event on origin, for code on origin: The Checkout Action
@@ -54,6 +55,8 @@ async function runAction() {
 		//   first
 		git.checkOutRemoteBranch(context);
 	}
+
+	let headSha = git.getHeadSha();
 
 	const checks = [];
 
@@ -104,11 +107,15 @@ async function runAction() {
 		}
 	}
 
+	log(""); // Create empty line in logs
+
 	// Add commit annotations after running all linters. To be displayed on pull requests, the
 	// annotations must be added to the last commit on the branch. This can either be a user commit or
 	// one of the auto-fix commits
-	log(""); // Create empty line in logs
-	const headSha = git.getHeadSha();
+	if (isPullRequest) {
+		headSha = git.getHeadSha();
+	}
+
 	await Promise.all(
 		checks.map(({ lintCheckName, lintResult, summary }) =>
 			createCheck(lintCheckName, headSha, context, lintResult, summary),

--- a/src/index.js
+++ b/src/index.js
@@ -112,7 +112,7 @@ async function runAction() {
 	// Add commit annotations after running all linters. To be displayed on pull requests, the
 	// annotations must be added to the last commit on the branch. This can either be a user commit or
 	// one of the auto-fix commits
-	if (isPullRequest) {
+	if (isPullRequest && autoFix) {
 		headSha = git.getHeadSha();
 	}
 


### PR DESCRIPTION
Currently the annotations are attached to the latest commit for commits to a branch.

![image](https://user-images.githubusercontent.com/617637/100471859-6ecf9100-30db-11eb-93eb-a990619f8ba9.png)

In the example above the check belongs to the "Update token" commit.