### PR TITLE
Add continue_on_error input

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ jobs:
 
 - **`github_token`:** The `GITHUB_TOKEN` to [authenticate on behalf of GitHub Actions](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow).
 
-- **`continue_on_error`:** Whether the workflow run should also fail when linter failures are detected. Default: `false`
+- **`continue_on_error`:** Whether the workflow run should also fail when linter failures are detected. Default: `true`
 
 - **`auto_fix`:** Whether linters should try to fix code style issues automatically. If some issues can be fixed, the action will commit and push the changes to the corresponding branch. Default: `false`
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ jobs:
       - name: Run linters
         uses: wearerequired/lint-action@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           # Enable your linters here
 ```
 
@@ -101,7 +101,7 @@ jobs:
       - name: Run linters
         uses: wearerequired/lint-action@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           # Enable linters
           eslint: true
           prettier: true
@@ -133,7 +133,7 @@ jobs:
       - name: Run linters
         uses: wearerequired/lint-action@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           # Enable linters
           php_codesniffer: true
           # Optional: Ignore warnings
@@ -171,7 +171,7 @@ jobs:
       - name: Run linters
         uses: wearerequired/lint-action@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           # Enable linters
           php_codesniffer: true
 ```
@@ -203,7 +203,7 @@ jobs:
       - name: Run linters
         uses: wearerequired/lint-action@v1
         with:
-          github_token: ${{ secrets.github_token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           # Enable linters
           black: true
           flake8: true
@@ -222,6 +222,10 @@ jobs:
 - **`[linter]_command_prefix`:** Command prefix to be run before the linter command. Default: `""`.
 
 ### General options
+
+- **`github_token`:** The `GITHUB_TOKEN` to [authenticate on behalf of GitHub Actions](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow).
+
+- **`continue_on_error`:** Whether the workflow run should also fail when linter failures are detected. Default: `false`
 
 - **`auto_fix`:** Whether linters should try to fix code style issues automatically. If some issues can be fixed, the action will commit and push the changes to the corresponding branch. Default: `false`
 

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
   github_token:
     description: The GITHUB_TOKEN secret
     required: true
+  continue_on_error:
+    description: Whether the workflow run should fail when a linter fails
+    required: false
+    default: "true"
   auto_fix:
     description: Whether linters should try to fix code style issues automatically
     required: false

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: The GITHUB_TOKEN secret
     required: true
   continue_on_error:
-    description: Whether the workflow run should fail when a linter fails
+    description: Whether the workflow run should also fail when linter failures are detected
     required: false
     default: "true"
   auto_fix:

--- a/dist/index.js
+++ b/dist/index.js
@@ -1114,6 +1114,7 @@ process.on("unhandledRejection", (err) => {
 async function runAction() {
 	const context = getContext();
 	const autoFix = core.getInput("auto_fix") === "true";
+	const continueOnError = core.getInput("continue_on_error") === "true";
 	const gitName = core.getInput("git_name", { required: true });
 	const gitEmail = core.getInput("git_email", { required: true });
 	const commitMessage = core.getInput("commit_message", { required: true });
@@ -1151,6 +1152,7 @@ async function runAction() {
 
 	let headSha = git.getHeadSha();
 
+	let hasFailures = false;
 	const checks = [];
 
 	// Loop over all available linters
@@ -1187,6 +1189,10 @@ async function runAction() {
 				`${linter.name} found ${summary} (${lintResult.isSuccess ? "success" : "failure"})`,
 			);
 
+			if (!lintResult.isSuccess) {
+				hasFailures = true;
+			}
+
 			if (autoFix) {
 				// Commit and push auto-fix changes
 				if (git.hasChanges()) {
@@ -1218,6 +1224,10 @@ async function runAction() {
 			createCheck(lintCheckName, headSha, context, lintResult, summary),
 		),
 	);
+
+	if (hasFailures && !continueOnError) {
+		core.setFailed("Linting failures detected");
+	}
 }
 
 runAction();

--- a/dist/index.js
+++ b/dist/index.js
@@ -1219,7 +1219,7 @@ async function runAction() {
 		headSha = git.getHeadSha();
 	}
 
-	core.startGroup('Create check runs with commit annotations')
+	core.startGroup("Create check runs with commit annotations");
 	await Promise.all(
 		checks.map(({ lintCheckName, lintResult, summary }) =>
 			createCheck(lintCheckName, headSha, context, lintResult, summary),

--- a/dist/index.js
+++ b/dist/index.js
@@ -1219,14 +1219,16 @@ async function runAction() {
 		headSha = git.getHeadSha();
 	}
 
+	core.startGroup('Create check runs with commit annotations')
 	await Promise.all(
 		checks.map(({ lintCheckName, lintResult, summary }) =>
 			createCheck(lintCheckName, headSha, context, lintResult, summary),
 		),
 	);
+	core.endGroup();
 
 	if (hasFailures && !continueOnError) {
-		core.setFailed("Linting failures detected");
+		core.setFailed("Linting failures detected. See check runs with annotations for details.");
 	}
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -125,14 +125,16 @@ async function runAction() {
 		headSha = git.getHeadSha();
 	}
 
+	core.startGroup('Create check runs with commit annotations')
 	await Promise.all(
 		checks.map(({ lintCheckName, lintResult, summary }) =>
 			createCheck(lintCheckName, headSha, context, lintResult, summary),
 		),
 	);
+	core.endGroup();
 
 	if (hasFailures && !continueOnError) {
-		core.setFailed("Linting failures detected");
+		core.setFailed("Linting failures detected. See check runs with annotations for details.");
 	}
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -125,7 +125,7 @@ async function runAction() {
 		headSha = git.getHeadSha();
 	}
 
-	core.startGroup('Create check runs with commit annotations')
+	core.startGroup("Create check runs with commit annotations");
 	await Promise.all(
 		checks.map(({ lintCheckName, lintResult, summary }) =>
 			createCheck(lintCheckName, headSha, context, lintResult, summary),

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ process.on("unhandledRejection", (err) => {
 async function runAction() {
 	const context = getContext();
 	const autoFix = core.getInput("auto_fix") === "true";
+	const continueOnError = core.getInput("continue_on_error") === "true";
 	const gitName = core.getInput("git_name", { required: true });
 	const gitEmail = core.getInput("git_email", { required: true });
 	const commitMessage = core.getInput("commit_message", { required: true });
@@ -57,6 +58,7 @@ async function runAction() {
 
 	let headSha = git.getHeadSha();
 
+	let hasFailures = false;
 	const checks = [];
 
 	// Loop over all available linters
@@ -93,6 +95,10 @@ async function runAction() {
 				`${linter.name} found ${summary} (${lintResult.isSuccess ? "success" : "failure"})`,
 			);
 
+			if (!lintResult.isSuccess) {
+				hasFailures = true;
+			}
+
 			if (autoFix) {
 				// Commit and push auto-fix changes
 				if (git.hasChanges()) {
@@ -124,6 +130,10 @@ async function runAction() {
 			createCheck(lintCheckName, headSha, context, lintResult, summary),
 		),
 	);
+
+	if (hasFailures && !continueOnError) {
+		core.setFailed("Linting failures detected");
+	}
 }
 
 runAction();


### PR DESCRIPTION
Fixes #60.

This adds a new input option `continue_on_error` to allow the main run to fail the workflow. For v1 the default will be `true` to keep the current behaviour.