### PR TITLE
Use --overwrite option for mint to fix macOS tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,9 +150,9 @@ jobs:
           brew update >/dev/null
           brew install mint
           cd ./test/linters/projects/swift-format-lockwood/
-          mint bootstrap --link --overwrite
+          mint bootstrap --link --overwrite=y
           cd ../swiftlint/
-          mint bootstrap --link --overwrite
+          mint bootstrap --link --overwrite=y
 
       # Tests
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,12 +149,10 @@ jobs:
         run: |
           brew update >/dev/null
           brew install mint
-          # If installed, unlink swiftlint, workaround for https://github.com/yonaskolb/Mint/issues/182
-          brew unlink swiftlint || true
           cd ./test/linters/projects/swift-format-lockwood/
-          mint bootstrap --link
+          mint bootstrap --link --overwrite
           cd ../swiftlint/
-          mint bootstrap --link
+          mint bootstrap --link --overwrite
 
       # Tests
 


### PR DESCRIPTION
This should fix the current macOS build errors.

```
🍺  /usr/local/Cellar/mint/0.16.0: 6 files, 3MB
Error: No such keg: /usr/local/Cellar/swiftlint
🌱 Linked swiftformat 0.43.5 to /usr/local/bin
🌱 1 package up to date
🌱  An executable that was not installed by mint already exists at /usr/local/bin/swiftlint.
Overwrite it with Mint's symlink? (y/n) 
Error: Process completed with exit code 1.
```

Related: https://github.com/yonaskolb/Mint/releases/tag/0.16.0