### PR TITLE
Increase maxBuffer from 1MB to 20MB to avoid truncated linting results

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2636,7 +2636,11 @@ function run(cmd, options) {
 	core.debug(cmd);
 
 	try {
-		const stdout = execSync(cmd, { encoding: "utf8", cwd: optionsWithDefaults.dir });
+		const stdout = execSync(cmd, {
+			encoding: "utf8",
+			cwd: optionsWithDefaults.dir,
+			maxBuffer: 20 * 1024 * 1024,
+		});
 		const output = {
 			status: 0,
 			stdout: stdout.trim(),

--- a/src/utils/action.js
+++ b/src/utils/action.js
@@ -40,7 +40,11 @@ function run(cmd, options) {
 	core.debug(cmd);
 
 	try {
-		const stdout = execSync(cmd, { encoding: "utf8", cwd: optionsWithDefaults.dir });
+		const stdout = execSync(cmd, {
+			encoding: "utf8",
+			cwd: optionsWithDefaults.dir,
+			maxBuffer: 20 * 1024 * 1024,
+		});
 		const output = {
 			status: 0,
 			stdout: stdout.trim(),


### PR DESCRIPTION
Fixes #96.