### PR TITLE
Use git reset instead of git branch

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -29,7 +29,7 @@ function checkOutRemoteBranch(context) {
 
 	// Switch to remote branch
 	core.info(`Switching to the "${context.branch}" branch`);
-	run(`git branch --force ${context.branch} --track ${remote}/${context.branch}`);
+	run(`git reset --hard ${remote}/${context.branch}`);
 	run(`git checkout ${context.branch}`);
 }
 

--- a/src/git.js
+++ b/src/git.js
@@ -29,8 +29,8 @@ function checkOutRemoteBranch(context) {
 
 	// Switch to remote branch
 	core.info(`Switching to the "${context.branch}" branch`);
-	run(`git reset --hard ${remote}/${context.branch}`);
 	run(`git checkout ${context.branch}`);
+	run(`git reset --hard ${remote}/${context.branch}`);
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/wearerequired/lint-action/issues/193

We were having trouble with fork PRs as many people. We were able to fix the problem, like many using the new `pull_request_target` event(https://github.com/wearerequired/lint-action/issues/13#issuecomment-669860138). 

Though it was still failing on this one PR: https://github.com/join-monster/join-monster/pull/444. We discovered this was because of the following error message:

![image](https://user-images.githubusercontent.com/7255363/116650698-ba6abd00-a94f-11eb-8c01-121daa202017.png)

I believe this comment is correct (https://github.com/wearerequired/lint-action/issues/13#issuecomment-708611002) and that this will fix the issue.
