### PR TITLE
git: ignore vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules/
+
+# vim swap files
+.*.sw?


### PR DESCRIPTION
Ignore any swap files written out by vim.  This helps anyone who may use
vim as an editor.