### PR TITLE
Use slash to allow testing on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
 		"eslint-plugin-jsdoc": "^33.0.0",
 		"fs-extra": "^9.1.0",
 		"jest": "^26.6.3",
-		"prettier": "^2.2.1"
+		"prettier": "^2.2.1",
+		"slash": "^3.0.0"
 	},
 	"eslintConfig": {
 		"root": true,

--- a/test/linters/params/swift-format-official.js
+++ b/test/linters/params/swift-format-official.js
@@ -1,5 +1,7 @@
 const { join } = require("path");
 
+const slash = require("slash");
+
 const SwiftFormatOfficial = require("../../../src/linters/swift-format-official");
 
 const testName = "swift-format-official";
@@ -8,10 +10,10 @@ const commandPrefix = "";
 const extensions = ["swift"];
 
 function getLintParams(dir) {
-	const warning1 = `${join(dir, "file2.swift")}:2:22: warning: [DoNotUseSemicolons]: remove ';'`;
-	const warning2 = `${join(dir, "file1.swift")}:3:35: warning: [RemoveLine]: remove line break`;
-	const warning3 = `${join(dir, "file1.swift")}:7:1: warning: [Indentation] replace leading whitespace with 2 spaces`;
-	const warning4 = `${join(dir, "file1.swift")}:7:23: warning: [Spacing]: add 1 space`;
+	const warning1 = `${slash(join(dir, "file2.swift"))}:2:22: warning: [DoNotUseSemicolons]: remove ';'`;
+	const warning2 = `${slash(join(dir, "file1.swift"))}:3:35: warning: [RemoveLine]: remove line break`;
+	const warning3 = `${slash(join(dir, "file1.swift"))}:7:1: warning: [Indentation] replace leading whitespace with 2 spaces`;
+	const warning4 = `${slash(join(dir, "file1.swift"))}:7:23: warning: [Spacing]: add 1 space`;
 	// Files on macOS are not sorted.
 	const stderr =
 		process.platform === "darwin"

--- a/test/linters/params/swift-format-official.js
+++ b/test/linters/params/swift-format-official.js
@@ -10,10 +10,7 @@ const extensions = ["swift"];
 function getLintParams(dir) {
 	const warning1 = `${join(dir, "file2.swift")}:2:22: warning: [DoNotUseSemicolons]: remove ';'`;
 	const warning2 = `${join(dir, "file1.swift")}:3:35: warning: [RemoveLine]: remove line break`;
-	const warning3 = `${join(
-		dir,
-		"file1.swift",
-	)}:7:1: warning: [Indentation] replace leading whitespace with 2 spaces`;
+	const warning3 = `${join(dir, "file1.swift")}:7:1: warning: [Indentation] replace leading whitespace with 2 spaces`;
 	const warning4 = `${join(dir, "file1.swift")}:7:23: warning: [Spacing]: add 1 space`;
 	// Files on macOS are not sorted.
 	const stderr =


### PR DESCRIPTION
Normalize the paths to the expected value on Windows when running `swift-format`.  This has no bearing on the action itself, just is a clean up required to get tests to work on Windows.