### PR TITLE
test: support test.utils.command-exists on Windows

### DIFF
--- a/test/utils/command-exists.test.js
+++ b/test/utils/command-exists.test.js
@@ -2,7 +2,11 @@ const commandExists = require("../../src/utils/command-exists");
 
 describe("commandExists()", () => {
 	test("should return `true` for existing command", async () => {
-		await expect(commandExists("cat")).resolves.toEqual(true);
+		if (process.platform === "win32") {
+			await expect(commandExists("cmd")).resolves.toEqual(true);
+		} else {
+			await expect(commandExists("cat")).resolves.toEqual(true);
+                }
 	});
 
 	test("should return `false` for non-existent command", async () => {


### PR DESCRIPTION
`cat` is a common utility on Unix systems, however, it is not
universally available.  On Windows systems, resort to `cmd` (%COMSPEC%)
as the shell interpreter is guaranteed to be present.  It stands to
reason that `sh` would be a viable alternative to `cat` as that is the
default (POSIX) shell interpreter on Unix systems and should be present
on any SuS or POSIX complaint system.