### PR TITLE
test: enable swift-format (official) testing on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,6 +154,40 @@ jobs:
           cd ../swiftlint/
           mint bootstrap --link --overwrite=y
 
+      # Swift (only on Windows)
+      - uses: seanmiddleditch/gha-setup-vsdevenv@master
+        if: startsWith(matrix.os, 'windows')
+
+      - name: Setup Swift 5.5-DEVELOPMENT-SNAPSHOT-2021-05-02-a (Windows)
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          # Install Toolchain
+          Install-Binary -Url "https://swift.org/builds/swift-5.5-branch/windows10/swift-5.5-DEVELOPMENT-SNAPSHOT-2021-05-02-a/swift-5.5-DEVELOPMENT-SNAPSHOT-2021-05-02-a-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
+          # Setup Environment Variables
+          echo "SDKROOT=C:\Library\Developer\Platforms\Windows.platform\Developer\SDKs\Windows.sdk" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "DEVELOPER_DIR=C:\Library\Developer" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          # Adjust Path
+          echo "C:\Library\Swift-development\bin;C:\Library\icu-67\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Copy Supporting Files (Windows)
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          # Copy Support Files
+          Copy-Item "$env:SDKROOT\usr\share\ucrt.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\ucrt\module.modulemap"
+          Copy-Item "$env:SDKROOT\usr\share\visualc.modulemap" -destination "$env:VCToolsInstallDir\include\module.modulemap"
+          Copy-Item "$env:SDKROOT\usr\share\visualc.apinotes" -destination "$env:VCToolsInstallDir\include\visualc.apinotes"
+          Copy-Item "$env:SDKROOT\usr\share\winsdk.modulemap" -destination "$env:UniversalCRTSdkDir\Include\$env:UCRTVersion\um\module.modulemap"
+
+      - name: Download swift-format (Windows)
+        if: startsWith(matrix.os, 'windows')
+        uses: robinraju/release-downloader@v1
+        with:
+          repository: compnerd/swift-build
+          tag: swift-format-5.5-DEVELOPMENT-SNAPSHOT-2021-05-02-a
+          fileName: swift-format.exe
+          out-file-path: C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\
+
       # Tests
 
       - name: Run tests

--- a/test/linters/linters.test.js
+++ b/test/linters/linters.test.js
@@ -15,7 +15,7 @@ const prettierParams = require("./params/prettier");
 const ruboCopParams = require("./params/rubocop");
 const stylelintParams = require("./params/stylelint");
 const swiftFormatLockwood = require("./params/swift-format-lockwood");
-// const swiftFormatOfficial = require("./params/swift-format-official");
+const swiftFormatOfficial = require("./params/swift-format-official");
 const swiftlintParams = require("./params/swiftlint");
 const xoParams = require("./params/xo");
 
@@ -40,6 +40,9 @@ if (process.platform === "linux") {
 }
 if (process.platform === "darwin") {
 	linterParams.push(swiftFormatLockwood, swiftlintParams);
+}
+if (process.platform === "win32") {
+	linterParams.push(swiftFormatOfficial);
 }
 
 const tmpDir = createTmpDir();


### PR DESCRIPTION
Add support to the CI to test the swift-format (official) based linting
on Windows.