### PR TITLE
add git_no_verify flag for potential hook issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,11 +267,11 @@ jobs:
     <img src="./.github/screenshots/auto-fix.png" alt="Screenshot of auto-fix commit" width="80%" />
   </p>
 
-- **`git_no_verify`:** Bypass the pre-commit and pre-push git hooks. Default: `false`
-
 - **`git_name`**: Username for auto-fix commits. Default: `"Lint Action"`
 
 - **`git_email`**: Email address for auto-fix commits. Default: `"lint-action@samuelmeuli.com"`
+
+- **`git_no_verify`**: Bypass the pre-commit and pre-push git hooks. Default: `false`
 
 - **`commit_message`**: Template for auto-fix commit messages. The `${linter}` variable can be used to insert the name of the linter. Default: `"Fix code style issues with ${linter}"`
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ jobs:
     <img src="./.github/screenshots/auto-fix.png" alt="Screenshot of auto-fix commit" width="80%" />
   </p>
 
-- **`skip_verification`:** Appends --no-verify to commit and push actions. Default: `false`
+- **`git_no_verify`:** Bypass the pre-commit and pre-push git hooks. Default: `false`
 
 - **`git_name`**: Username for auto-fix commits. Default: `"Lint Action"`
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,8 @@ jobs:
     <img src="./.github/screenshots/auto-fix.png" alt="Screenshot of auto-fix commit" width="80%" />
   </p>
 
+- **`skip_verification`:** Appends --no-verify to commit and push actions. Default: `false`
+
 - **`git_name`**: Username for auto-fix commits. Default: `"Lint Action"`
 
 - **`git_email`**: Email address for auto-fix commits. Default: `"lint-action@samuelmeuli.com"`

--- a/action.yml
+++ b/action.yml
@@ -15,8 +15,8 @@ inputs:
     description: Whether linters should try to fix code style issues automatically
     required: false
     default: "false"
-  skip_verification:
-    description: 'Appends --no-verify to commit and push actions'
+  git_no_verify:
+    description: Bypass the pre-commit and pre-push git hooks
     required: false
     default: "false"
   git_name:

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: Whether linters should try to fix code style issues automatically
     required: false
     default: "false"
+  skip_verification:
+    description: 'Appends --no-verify to commit and push actions'
+    required: false
+    default: "false"
   git_name:
     description: Username for auto-fix commits
     required: false

--- a/src/git.js
+++ b/src/git.js
@@ -38,6 +38,7 @@ function checkOutRemoteBranch(context) {
 /**
  * Stages and commits all changes using Git
  * @param {string} message - Git commit message
+ * @param {boolean} skipVerification - Skip Git verification
  */
 function commitChanges(message, skipVerification) {
 	core.info(`Committing changes`);
@@ -67,6 +68,7 @@ function hasChanges() {
 
 /**
  * Pushes all changes to the remote repository
+ * @param {boolean} skipVerification - Skip Git verification
  */
 function pushChanges(skipVerification) {
 	core.info("Pushing changes with Git");

--- a/src/git.js
+++ b/src/git.js
@@ -39,9 +39,9 @@ function checkOutRemoteBranch(context) {
  * Stages and commits all changes using Git
  * @param {string} message - Git commit message
  */
-function commitChanges(message) {
+function commitChanges(message, skipVerification) {
 	core.info(`Committing changes`);
-	run(`git commit -am "${message}"`);
+	run(`git commit -am "${message}"${skipVerification ? " --no-verify" : ""}`);
 }
 
 /**
@@ -68,9 +68,9 @@ function hasChanges() {
 /**
  * Pushes all changes to the remote repository
  */
-function pushChanges() {
+function pushChanges(skipVerification) {
 	core.info("Pushing changes with Git");
-	run("git push");
+	run(`git push${skipVerification ? " --no-verify" : ""}`);
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const { getSummary } = require("./utils/lint-result");
 async function runAction() {
 	const context = getContext();
 	const autoFix = core.getInput("auto_fix") === "true";
-	const skipVerification = core.getInput("skip_verification") === "true";
+	const skipVerification = core.getInput("git_no_verify") === "true";
 	const continueOnError = core.getInput("continue_on_error") === "true";
 	const gitName = core.getInput("git_name", { required: true });
 	const gitEmail = core.getInput("git_email", { required: true });

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const { getSummary } = require("./utils/lint-result");
 async function runAction() {
 	const context = getContext();
 	const autoFix = core.getInput("auto_fix") === "true";
+	const skipVerification = core.getInput("skip_verification") === "true";
 	const continueOnError = core.getInput("continue_on_error") === "true";
 	const gitName = core.getInput("git_name", { required: true });
 	const gitEmail = core.getInput("git_email", { required: true });
@@ -98,8 +99,8 @@ async function runAction() {
 			if (autoFix) {
 				// Commit and push auto-fix changes
 				if (git.hasChanges()) {
-					git.commitChanges(commitMessage.replace(/\${linter}/g, linter.name));
-					git.pushChanges();
+					git.commitChanges(commitMessage.replace(/\${linter}/g, linter.name), skipVerification);
+					git.pushChanges(skipVerification);
 				}
 			}
 


### PR DESCRIPTION
Running into issues that if `eslint` and `prettier` both run on a file my npm pre-commit hook will fail. Suggesting this but also running 

If you'd like to close / logging for SEO that in the meantime I'm also just running this .yml between ci and lint-action: 

```
      - name: Remove commit hooks
        run: rm .git/hooks/pre-commit
        run: rm .git/hooks/pre-push
```