### PR TITLE
feature and suggestion: additional error handing. [check if black_dir and flake8_dir exist.]

### DIFF
--- a/src/linters/black.js
+++ b/src/linters/black.js
@@ -1,3 +1,5 @@
+const { existsSync } = require('fs');
+
 const { run } = require("../utils/action");
 const commandExists = require("../utils/command-exists");
 const { parseErrorsFromDiff } = require("../utils/diff");
@@ -22,6 +24,11 @@ class Black {
 		// Verify that Python is installed (required to execute Black)
 		if (!(await commandExists("python"))) {
 			throw new Error("Python is not installed");
+		}
+
+		// Check if black_dir exists
+		if (dir && !existsSync(dir)) {
+			throw new Error(`${this.name}_dir doesn't exist.`);
 		}
 
 		// Verify that Black is installed

--- a/src/linters/flake8.js
+++ b/src/linters/flake8.js
@@ -1,3 +1,4 @@
+const { existsSync } = require('fs');
 const { sep } = require("path");
 
 const core = require("@actions/core");
@@ -28,6 +29,11 @@ class Flake8 {
 		// Verify that Python is installed (required to execute Flake8)
 		if (!(await commandExists("python"))) {
 			throw new Error("Python is not installed");
+		}
+
+		// Check if flake8_dir exists
+		if (dir && !existsSync(dir)) {
+			throw new Error(`${this.name}_dir doesn't exist.`);
 		}
 
 		// Verify that Flake8 is installed


### PR DESCRIPTION
[suggestion]
It was unfriendly to be said 'flake8 is not installed' or 'black is not installed' when I made a mistake in the path of flake8_dir or black_dir.
So I towards to do another way to check the existence of flake8_dir and black_dir paths.

I guess it would be better if other linters had similar settings, but this time I made a pull request only for flake8 and black.

- Check if black_dir exists
- Check if flake8_dir exists