### PR TITLE
Add prefix to mypy check

### DIFF
--- a/src/linters/mypy.js
+++ b/src/linters/mypy.js
@@ -31,7 +31,7 @@ class Mypy {
 		}
 
 		// Verify that Mypy is installed
-		if (!(await commandExists("mypy"))) {
+		if (!(await commandExists("${prefix} mypy"))) {
 			throw new Error(`${this.name} is not installed`);
 		}
 	}

--- a/src/linters/mypy.js
+++ b/src/linters/mypy.js
@@ -31,7 +31,9 @@ class Mypy {
 		}
 
 		// Verify that Mypy is installed
-		if (!(await commandExists("${prefix} mypy"))) {
+		try {
+			run(`${prefix} mypy --version`, { dir });
+		} catch (err) {
 			throw new Error(`${this.name} is not installed`);
 		}
 	}


### PR DESCRIPTION
Right now checking for `mypy` fails if you require a prefix (for example, `poetry run` in my case). This PR solves this problem. 