### PR TITLE
Improve handling for failed check runs

### DIFF
--- a/src/github/api.js
+++ b/src/github/api.js
@@ -79,8 +79,23 @@ async function createCheck(linterName, sha, context, lintResult, neutralCheckOnW
 		});
 		core.info(`${linterName} check created successfully`);
 	} catch (err) {
-		core.error(err);
-		throw new Error(`Error trying to create GitHub check for ${linterName}: ${err.message}`);
+		let errorMessage = err.message;
+		if (err.data) {
+			try {
+				const errorData = JSON.parse(err.data);
+				if (errorData.message) {
+					errorMessage += `. ${errorData.message}`;
+				}
+				if (errorData.documentation_url) {
+					errorMessage += ` ${errorData.documentation_url}`;
+				}
+			} catch (e) {
+				// Ignore
+			}
+		}
+		core.error(errorMessage);
+
+		throw new Error(`Error trying to create GitHub check for ${linterName}: ${errorMessage}`);
 	}
 }
 


### PR DESCRIPTION
* Show full error message including documentation URL, see https://docs.github.com/en/rest/overview/resources-in-the-rest-api#client-errors
* Don't let the action fail if a check run could not be created

Supersedes #347.