### PR TITLE
Enhance check for missing permissions on forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,16 @@ on:
   push:
     branches:
       - main
+  # Replace pull_request with pull_request_target if you
+  # plan to use this action with forks, see the Limitations section
   pull_request:
     branches:
       - main
+
+# Down scope as necessary via https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+permissions:
+  checks: write
+  contents: write
 
 jobs:
   run-linters:
@@ -310,9 +317,7 @@ Some options are not be available for specific linters:
 There are currently some limitations as to how this action (or any other action) can be used in the context of `pull_request` events from forks:
 
 - The action doesn't have permission to push auto-fix changes to the fork. This is because the `pull_request` event runs on the upstream repo, where the `github_token` is lacking permissions for the fork. [Source](https://github.community/t5/GitHub-Actions/Can-t-push-to-forked-repository-on-the-original-repository-s/m-p/35916/highlight/true#M2372)
-- The action doesn't have permission to create annotations for commits on forks and can therefore not display linting errors. [Source 1](https://github.community/t5/GitHub-Actions/Token-permissions-for-forks-once-again/m-p/33839), [source 2](https://github.com/actions/labeler/issues/12)
-
-For details and comments, please refer to [#13](https://github.com/wearerequired/lint-action/issues/13).
+- The action doesn't have permission to create annotations for commits on forks unless you use the `pull_request_target` event. You can modify the default permissions granted to the `GITHUB_TOKEN` by using the `permissions` key and set the `checks` scope to `write`. See [GitHub documentation](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#permissions) for more.
 
 ### Auto-fixing workflow files
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,15 +25,15 @@ async function runAction() {
 		context.eventName === "pull_request" || context.eventName === "pull_request_target";
 
 	// If on a PR from fork: Display messages regarding action limitations
-	if (isPullRequest && context.repository.hasFork) {
+	if (context.eventName === "pull_request" && context.repository.hasFork) {
 		core.error(
-			"This action does not have permission to create annotations on forks. You may want to run it only on `push` events. See https://github.com/wearerequired/lint-action/issues/13 for details",
+			"This action does not have permission to create annotations on forks. You may want to run it only on `pull_request_target` events with checks permissions set to write. See https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#permissions for details.",
 		);
-		if (autoFix) {
-			core.error(
-				"This action does not have permission to push to forks. You may want to run it only on `push` events. See https://github.com/wearerequired/lint-action/issues/13 for details",
-			);
-		}
+	}
+	if (isPullRequest && context.repository.hasFork && autoFix) {
+		core.error(
+			"This action does not have permission to push to forks. You may want to run it only on `push` events.",
+		);
 	}
 
 	if (autoFix) {


### PR DESCRIPTION
Don't show error for forks when using `pull_request_target` event. Update example to mention `pull_request_target` and how to down scope as necessary.

* https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request_target
* https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token