### PR TITLE
Add auto_commit input

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,11 +312,13 @@ jobs:
 
 - **`continue_on_error`:** Whether the workflow run should also fail when linter failures are detected. Default: `true`
 
-- **`auto_fix`:** Whether linters should try to fix code style issues automatically. If some issues can be fixed, the action will commit and push the changes to the corresponding branch. Default: `false`
+- **`auto_fix`:** Whether linters should try to fix code style issues automatically. If some issues can be fixed, the action will apply the needed changes. Default: `false`
 
   <p align="center">
     <img src="./.github/screenshots/auto-fix.png" alt="Screenshot of auto-fix commit" width="80%" />
   </p>
+
+- **`auto_commit`:** Whether to commit and push the changes made by `auto_fix`. Default: `false`
 
 - **`git_name`**: Username for auto-fix commits. Default: `"Lint Action"`
 

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ jobs:
     <img src="./.github/screenshots/auto-fix.png" alt="Screenshot of auto-fix commit" width="80%" />
   </p>
 
-- **`auto_commit`:** Whether to commit and push the changes made by `auto_fix`. Default: `false`
+- **`commit`:** Whether to commit and push the changes made by `auto_fix`. Default: `true`
 
 - **`git_name`**: Username for auto-fix commits. Default: `"Lint Action"`
 

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: Whether linters should try to fix code style issues automatically
     required: false
     default: "false"
+  auto_commit:
+    description: Whether linters should try to fix code style issues automatically
+    required: false
+    default: "true"
   git_no_verify:
     description: Bypass the pre-commit and pre-push git hooks
     required: false

--- a/action.yml
+++ b/action.yml
@@ -15,8 +15,8 @@ inputs:
     description: Whether linters should try to fix code style issues automatically
     required: false
     default: "false"
-  auto_commit:
-    description: Whether linters should try to fix code style issues automatically
+  commit:
+    description: Whether to commit and push the changes made by auto_fix
     required: false
     default: "true"
   git_no_verify:

--- a/dist/index.js
+++ b/dist/index.js
@@ -4317,7 +4317,7 @@ const { getSummary } = __nccwpck_require__(9149);
 async function runAction() {
 	const context = getContext();
 	const autoFix = core.getInput("auto_fix") === "true";
-	const autoCommit = core.getInput("auto_commit") === "true";
+	const commit = core.getInput("commit") === "true";
 	const skipVerification = core.getInput("git_no_verify") === "true";
 	const continueOnError = core.getInput("continue_on_error") === "true";
 	const gitName = core.getInput("git_name", { required: true });
@@ -4401,7 +4401,7 @@ async function runAction() {
 				hasFailures = true;
 			}
 
-			if (autoFix && autoCommit) {
+			if (autoFix && commit) {
 				// Commit and push auto-fix changes
 				if (git.hasChanges()) {
 					git.commitChanges(commitMessage.replace(/\${linter}/g, linter.name), skipVerification);

--- a/dist/index.js
+++ b/dist/index.js
@@ -4317,6 +4317,7 @@ const { getSummary } = __nccwpck_require__(9149);
 async function runAction() {
 	const context = getContext();
 	const autoFix = core.getInput("auto_fix") === "true";
+	const autoCommit = core.getInput("auto_commit") === "true";
 	const skipVerification = core.getInput("git_no_verify") === "true";
 	const continueOnError = core.getInput("continue_on_error") === "true";
 	const gitName = core.getInput("git_name", { required: true });
@@ -4400,7 +4401,7 @@ async function runAction() {
 				hasFailures = true;
 			}
 
-			if (autoFix) {
+			if (autoFix && autoCommit) {
 				// Commit and push auto-fix changes
 				if (git.hasChanges()) {
 					git.commitChanges(commitMessage.replace(/\${linter}/g, linter.name), skipVerification);

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const { getSummary } = require("./utils/lint-result");
 async function runAction() {
 	const context = getContext();
 	const autoFix = core.getInput("auto_fix") === "true";
+	const autoCommit = core.getInput("auto_commit") === "true";
 	const skipVerification = core.getInput("git_no_verify") === "true";
 	const continueOnError = core.getInput("continue_on_error") === "true";
 	const gitName = core.getInput("git_name", { required: true });
@@ -97,7 +98,7 @@ async function runAction() {
 				hasFailures = true;
 			}
 
-			if (autoFix) {
+			if (autoFix && autoCommit) {
 				// Commit and push auto-fix changes
 				if (git.hasChanges()) {
 					git.commitChanges(commitMessage.replace(/\${linter}/g, linter.name), skipVerification);

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const { getSummary } = require("./utils/lint-result");
 async function runAction() {
 	const context = getContext();
 	const autoFix = core.getInput("auto_fix") === "true";
-	const autoCommit = core.getInput("auto_commit") === "true";
+	const commit = core.getInput("commit") === "true";
 	const skipVerification = core.getInput("git_no_verify") === "true";
 	const continueOnError = core.getInput("continue_on_error") === "true";
 	const gitName = core.getInput("git_name", { required: true });
@@ -98,7 +98,7 @@ async function runAction() {
 				hasFailures = true;
 			}
 
-			if (autoFix && autoCommit) {
+			if (autoFix && commit) {
 				// Commit and push auto-fix changes
 				if (git.hasChanges()) {
 					git.commitChanges(commitMessage.replace(/\${linter}/g, linter.name), skipVerification);


### PR DESCRIPTION
Adds `auto_commit` to prevent commits when `auto_fix` is enabled.

This allows someone to do this:
```yaml
- name: Run linters
  uses: wearerequired/lint-action@master
  with:
    auto_fix: true
    auto_commit: false
    mypy: true
    mypy_args: >
      --follow-imports=silent
      --ignore-missing-imports
      --implicit-optional
      --no-strict-optional
    autopep8: true
    autopep8_args: >
      --max-line-length 120
- name: suggester / lint
  uses: reviewdog/action-suggester@v1
  with:
    tool_name: lint
```
which gives you the `mypy` messages from `lint-action` but with the `autopep8` changes as suggested changes via `reviewdog`.

Pretty much resolves #436 as it can be achieved through `reviewdog`.