### PR TITLE
Use only CSS as default extension for stylelint

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ inputs:
   stylelint_extensions:
     description: Extensions of files to check with stylelint
     required: false
-    default: "css,sass,scss"
+    default: "css"
   stylelint_command_prefix:
     description: Shell command to prepend to the linter command
     required: false


### PR DESCRIPTION
Fixes #352.

[Stylelint 14.0.0](https://stylelint.io/migration-guide/to-14/) only supports CSS by default. Any other extension requires to install an appropriate syntax.