### PR TITLE
docs: dotnet-format fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,9 +179,6 @@ jobs:
         with:
           dotnet-version: "6.0.x"
 
-      - name: Install dotnet-format
-        run: dotnet tool install -g dotnet-format
-
       # Tests
 
       - name: Install test dependencies

--- a/README.md
+++ b/README.md
@@ -285,9 +285,6 @@ jobs:
         with:
           dotnet-version: "6.0.x"
 
-      - name: Install dotnet-format
-        run: dotnet tool install -g dotnet-format
-
       - name: Run linters
         uses: wearerequired/lint-action@v2
         with:
@@ -385,7 +382,7 @@ Some options are not be available for specific linters:
 | --------------------- | :---------: | :--------: |
 | autopep8              |     ✅      |  ❌ (py)   |
 | black                 |     ✅      |     ✅     |
-| dotnet_format         |     ✅      |     ✅     |
+| dotnet_format         |     ✅      |  ❌ (cs)   |
 | erblint               |     ❌      |  ❌ (erb)  |
 | eslint                |     ✅      |     ✅     |
 | flake8                |     ❌      |     ✅     |


### PR DESCRIPTION
These are just some minor changes to reflect how a current setup is done with dotnet-format as the `dotnet tool install` command is no longer needed on the latest SDK's.

Also noticed that I fumbled a copy & paste on the linter support table as dotnet-format doesn't have extension options, so we got that fixed.