### PR TITLE
fix: skip git shenanigans if autofix is disabled

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5576,7 +5576,7 @@ async function runAction() {
 		// Set Git committer username and password
 		git.setUserInfo(gitName, gitEmail);
 	}
-	if (isPullRequest) {
+	if (autoFix && isPullRequest) {
 		// Fetch and check out PR branch:
 		// - "push" event: Already on correct branch
 		// - "pull_request" event on origin, for code on origin: The Checkout Action

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ async function runAction() {
 		// Set Git committer username and password
 		git.setUserInfo(gitName, gitEmail);
 	}
-	if (isPullRequest) {
+	if (autoFix && isPullRequest) {
 		// Fetch and check out PR branch:
 		// - "push" event: Already on correct branch
 		// - "pull_request" event on origin, for code on origin: The Checkout Action


### PR DESCRIPTION
Linting breaks on PRs that have received a force push. Note this this does not address the core issue but works around. Related: #193