### PR TITLE
Replace deprecated autocorrect command for swiftlint auto-fixing

### DIFF
--- a/src/linters/swiftlint.js
+++ b/src/linters/swiftlint.js
@@ -40,7 +40,7 @@ class SwiftLint {
 			throw new Error(`${this.name} error: File extensions are not configurable`);
 		}
 
-		const fixArg = fix ? "autocorrect" : "lint";
+		const fixArg = fix ? "--fix" : "";
 		return run(`${prefix} swiftlint ${fixArg} ${args}`, {
 			dir,
 			ignoreErrors: true,

--- a/test/linters/projects/swiftlint/Mintfile
+++ b/test/linters/projects/swiftlint/Mintfile
@@ -1,1 +1,1 @@
-realm/SwiftLint@0.45.1
+realm/SwiftLint@0.50.3


### PR DESCRIPTION
See https://github.com/realm/SwiftLint/blob/0.50.3/CHANGELOG.md#0490-asynchronous-defuzzer.