### PR TITLE
Support unconventional branch names

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -29,12 +29,12 @@ function checkOutRemoteBranch(context) {
 
 	// Fetch remote branch
 	core.info(`Fetching remote branch "${context.branch}"`);
-	run(`git fetch --no-tags --depth=1 ${remote} ${context.branch}`);
+	run(`git fetch --no-tags --depth=1 ${remote} "${context.branch}"`);
 
 	// Switch to remote branch
 	core.info(`Switching to the "${context.branch}" branch`);
-	run(`git branch --force ${context.branch} --track ${remote}/${context.branch}`);
-	run(`git checkout ${context.branch}`);
+	run(`git branch --force "${context.branch}" --track "${remote}/${context.branch}"`);
+	run(`git checkout "${context.branch}"`);
 }
 
 /**


### PR DESCRIPTION
### Problem

Renovate github action creates PRs with branch names containing parentheses.

When this action runs on such a branch, this happens:
```
Setting Git user information
Adding auth information to Git remote URL
Fetching remote branch "renovate/devdependencies-(non-major)"
/bin/sh: 1: Syntax error: "(" unexpected
Error: Command failed: git fetch --no-tags --depth=1 origin renovate/devdependencies-(non-major)
/bin/sh: 1: Syntax error: "(" unexpected
```

### Solution
Escape the string containing branch name so they can be checked out.