### PR TITLE
fix: handle branch names with special characters properly

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -29,12 +29,12 @@ function checkOutRemoteBranch(context) {
 
 	// Fetch remote branch
 	core.info(`Fetching remote branch "${context.branch}"`);
-	run(`git fetch --no-tags --depth=1 ${remote} ${context.branch}`);
+	run(`git fetch --no-tags --depth=1 "${remote}" "${context.branch}"`);
 
 	// Switch to remote branch
 	core.info(`Switching to the "${context.branch}" branch`);
-	run(`git branch --force ${context.branch} --track ${remote}/${context.branch}`);
-	run(`git checkout ${context.branch}`);
+	run(`git branch --force ${context.branch} --track "${remote}/${context.branch}"`);
+	run(`git checkout "${context.branch}"`);
 }
 
 /**


### PR DESCRIPTION
The git commands for branch names that contain special characters like parentheses would not work, unless they are in quotes.

This PR fixes that.