### PR TITLE
Add `deno lint` support 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,11 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         run: brew install clang-format
 
+      # Deno
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v1
+
       # Go
 
       - name: Set up Go

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ _**Note:** The behavior of actions like this one is currently limited in the con
   - [SwiftLint](https://github.com/realm/SwiftLint)
 - **TypeScript:**
   - [tsc](https://www.typescriptlang.org/docs/handbook/compiler-options.html)
+  - [deno lint](https://deno.land/manual/tools/linter)
 - **VB.NET:**
   - [dotnet-format](https://github.com/dotnet/format)
 
@@ -386,7 +387,7 @@ With `auto_fix` set to `true`, by default the action will try and fix code issue
 
 ### Linter-specific options
 
-`[linter]` can be one of `autopep8`, `black`, `clang_format`, `dotnet_format`, `erblint`, `eslint`, `flake8`, `gofmt`, `golint`, `mypy`, `oitnb`, `php_codesniffer`, `prettier`, `pylint`, `rubocop`, `stylelint`, `swift_format_official`, `swift_format_lockwood`, `swiftlint` and `xo`:
+`[linter]` can be one of `autopep8`, `black`, `clang_format`, `deno_lint`, `dotnet_format`, `erblint`, `eslint`, `flake8`, `gofmt`, `golint`, `mypy`, `oitnb`, `php_codesniffer`, `prettier`, `pylint`, `rubocop`, `stylelint`, `swift_format_official`, `swift_format_lockwood`, `swiftlint` and `xo`:
 
 - **`[linter]`:** Enables the linter in your repository. Default: `false`
 - **`[linter]_args`**: Additional arguments to pass to the linter. Example: `eslint_args: "--max-warnings 0"` if ESLint checks should fail even if there are no errors and only warnings. Default: `""`
@@ -431,6 +432,7 @@ Some options are not available for specific linters:
 | black                 |     ✅      |     ✅     |
 | clang_format          |     ✅      |     ✅     |
 | clippy                |     ✅      |  ❌ (rs)   |
+| deno_lint             |     ❌      |  ❌ (ts)   |
 | dotnet_format         |     ✅      |  ❌ (cs)   |
 | erblint               |     ❌      |  ❌ (erb)  |
 | eslint                |     ✅      |     ✅     |

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ Some options are not available for specific linters:
 | black                 |     ✅      |     ✅     |
 | clang_format          |     ✅      |     ✅     |
 | clippy                |     ✅      |  ❌ (rs)   |
-| deno_lint             |     ❌      |  ❌ (ts)   |
+| deno_lint             |     ❌      |     ✅     |
 | dotnet_format         |     ✅      |  ❌ (cs)   |
 | erblint               |     ❌      |  ❌ (erb)  |
 | eslint                |     ✅      |     ✅     |

--- a/action.yml
+++ b/action.yml
@@ -220,6 +220,30 @@ inputs:
     required: false
     default: "false"
 
+  deno_lint:
+    description: Enable or disable deno lint checks
+    required: false
+    default: "false"
+  deno_lint_args:
+    description: Additional arguments to pass to the linter
+    required: false
+    default: ""
+  deno_lint_dir:
+    description: Directory where the deno lint command should be run
+    required: false
+  deno_lint_extensions:
+    description: Extensions of files to check with deno lint
+    required: false
+    default: "ts"
+  deno_lint_command_prefix:
+    description: Shell command to prepend to the linter command
+    required: false
+    default: ""
+  deno_lint_auto_fix:
+    description: Whether this linter should try to fix code style issues automatically. If set to `true`, it will only work if "auto_fix" is set to `true` as well
+    required: false
+    default: "false"
+
   # PHP
 
   php_codesniffer:

--- a/action.yml
+++ b/action.yml
@@ -234,7 +234,7 @@ inputs:
   deno_lint_extensions:
     description: Extensions of files to check with deno lint
     required: false
-    default: "ts"
+    default: "*"
   deno_lint_command_prefix:
     description: Shell command to prepend to the linter command
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -7269,15 +7269,28 @@ class DenoLint {
 	 * @returns {{status: number, stdout: string, stderr: string}} - Output of the lint command
 	 */
 	static lint(dir, extensions, args = "", fix = false, prefix = "") {
-		if (extensions.length !== 1 || extensions[0] !== "ts") {
-			throw new Error(`${this.name} error: File extensions are not configurable`);
-		}
-
 		if (fix) {
 			core.warning(`${this.name} does not support auto-fixing`);
 		}
 
-		return run(`${prefix} deno lint --json ${args}`, {
+		let targets;
+		switch (extensions.length) {
+			case 0:
+				targets = "";
+				break;
+			case 1:
+				if (extensions[0] === "*") {
+					targets = ""; // all files supported by deno lint
+				} else {
+					targets = `./**/*.${extensions[0]}`;
+				}
+				break;
+			default:
+				targets = `./**/*.{${extensions.map((ext) => ext).join(",")}}`;
+				break;
+		}
+
+		return run(`${prefix} deno lint ${targets} --json ${args}`, {
 			dir,
 			ignoreErrors: true,
 		});

--- a/dist/index.js
+++ b/dist/index.js
@@ -7227,6 +7227,102 @@ module.exports = Clippy;
 
 /***/ }),
 
+/***/ 4649:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+const core = __nccwpck_require__(2186);
+
+const { run } = __nccwpck_require__(9575);
+const commandExists = __nccwpck_require__(5265);
+const { initLintResult } = __nccwpck_require__(9149);
+const { removeTrailingPeriod } = __nccwpck_require__(9321);
+
+/** @typedef {import('../utils/lint-result').LintResult} LintResult */
+
+/**
+ * https://docs.deno.com/runtime/manual/tools/linter
+ */
+class DenoLint {
+	static get name() {
+		return "deno_lint";
+	}
+
+	/**
+	 * Verifies that all required programs are installed. Throws an error if programs are missing
+	 * @param {string} dir - Directory to run the linting program in
+	 * @param {string} prefix - Prefix to the lint command
+	 */
+	static async verifySetup(dir, prefix = "") {
+		// Verify that deno is installed
+		if (!(await commandExists("deno"))) {
+			throw new Error("deno is not installed");
+		}
+	}
+
+	/**
+	 * Runs the linting program and returns the command output
+	 * @param {string} dir - Directory to run the linter in
+	 * @param {string[]} extensions - File extensions which should be linted
+	 * @param {string} args - Additional arguments to pass to the linter
+	 * @param {boolean} fix - Whether the linter should attempt to fix code style issues automatically
+	 * @param {string} prefix - Prefix to the lint command
+	 * @returns {{status: number, stdout: string, stderr: string}} - Output of the lint command
+	 */
+	static lint(dir, extensions, args = "", fix = false, prefix = "") {
+		if (extensions.length !== 1 || extensions[0] !== "ts") {
+			throw new Error(`${this.name} error: File extensions are not configurable`);
+		}
+
+		if (fix) {
+			core.warning(`${this.name} does not support auto-fixing`);
+		}
+
+		return run(`${prefix} deno lint --json ${args}`, {
+			dir,
+			ignoreErrors: true,
+		});
+	}
+
+	/**
+	 * Parses the output of the lint command. Determines the success of the lint process and the
+	 * severity of the identified code style violations
+	 * @param {string} dir - Directory in which the linter has been run
+	 * @param {{status: number, stdout: string, stderr: string}} output - Output of the lint command
+	 * @returns {LintResult} - Parsed lint result
+	 */
+	static parseOutput(dir, output) {
+		const lintResult = initLintResult();
+		lintResult.isSuccess = output.status === 0;
+
+		let outputJson;
+		try {
+			outputJson = JSON.parse(output.stdout);
+		} catch (err) {
+			throw new Error(
+				`Error parsing ${this.name} JSON output: ${err.message}. Output: "${output.stdout}"`,
+			);
+		}
+
+		for (const diagnostics of outputJson.diagnostics) {
+			const { filename, range, code, message, hint } = diagnostics;
+			const path = filename.substring(dir.length + 1);
+			const entry = {
+				path,
+				firstLine: range.start.line,
+				lastLine: range.end.line,
+				message: `${removeTrailingPeriod(message)} (${code}, ${hint})`,
+			};
+			lintResult.warning.push(entry);
+		}
+		return lintResult;
+	}
+}
+
+module.exports = DenoLint;
+
+
+/***/ }),
+
 /***/ 6216:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
@@ -7831,6 +7927,7 @@ const Autopep8 = __nccwpck_require__(3569);
 const Black = __nccwpck_require__(9844);
 const ClangFormat = __nccwpck_require__(6632);
 const Clippy = __nccwpck_require__(244);
+const DenoLint = __nccwpck_require__(4649);
 const DotnetFormat = __nccwpck_require__(6216);
 const Erblint = __nccwpck_require__(9674);
 const ESLint = __nccwpck_require__(7169);
@@ -7854,6 +7951,7 @@ const XO = __nccwpck_require__(728);
 const linters = {
 	// Linters
 	clippy: Clippy,
+	deno_lint: DenoLint,
 	erblint: Erblint,
 	eslint: ESLint,
 	flake8: Flake8,

--- a/src/linters/deno-lint.js
+++ b/src/linters/deno-lint.js
@@ -1,0 +1,89 @@
+const core = require("@actions/core");
+
+const { run } = require("../utils/action");
+const commandExists = require("../utils/command-exists");
+const { initLintResult } = require("../utils/lint-result");
+const { removeTrailingPeriod } = require("../utils/string");
+
+/** @typedef {import('../utils/lint-result').LintResult} LintResult */
+
+/**
+ * https://docs.deno.com/runtime/manual/tools/linter
+ */
+class DenoLint {
+	static get name() {
+		return "deno_lint";
+	}
+
+	/**
+	 * Verifies that all required programs are installed. Throws an error if programs are missing
+	 * @param {string} dir - Directory to run the linting program in
+	 * @param {string} prefix - Prefix to the lint command
+	 */
+	static async verifySetup(dir, prefix = "") {
+		// Verify that deno is installed
+		if (!(await commandExists("deno"))) {
+			throw new Error("deno is not installed");
+		}
+	}
+
+	/**
+	 * Runs the linting program and returns the command output
+	 * @param {string} dir - Directory to run the linter in
+	 * @param {string[]} extensions - File extensions which should be linted
+	 * @param {string} args - Additional arguments to pass to the linter
+	 * @param {boolean} fix - Whether the linter should attempt to fix code style issues automatically
+	 * @param {string} prefix - Prefix to the lint command
+	 * @returns {{status: number, stdout: string, stderr: string}} - Output of the lint command
+	 */
+	static lint(dir, extensions, args = "", fix = false, prefix = "") {
+		if (extensions.length !== 1 || extensions[0] !== "ts") {
+			throw new Error(`${this.name} error: File extensions are not configurable`);
+		}
+
+		if (fix) {
+			core.warning(`${this.name} does not support auto-fixing`);
+		}
+
+		return run(`${prefix} deno lint --json ${args}`, {
+			dir,
+			ignoreErrors: true,
+		});
+	}
+
+	/**
+	 * Parses the output of the lint command. Determines the success of the lint process and the
+	 * severity of the identified code style violations
+	 * @param {string} dir - Directory in which the linter has been run
+	 * @param {{status: number, stdout: string, stderr: string}} output - Output of the lint command
+	 * @returns {LintResult} - Parsed lint result
+	 */
+	static parseOutput(dir, output) {
+		const lintResult = initLintResult();
+		lintResult.isSuccess = output.status === 0;
+
+		let outputJson;
+		try {
+			outputJson = JSON.parse(output.stdout);
+		} catch (err) {
+			throw new Error(
+				`Error parsing ${this.name} JSON output: ${err.message}. Output: "${output.stdout}"`,
+			);
+		}
+
+		for (const diagnostics of outputJson.diagnostics) {
+			const { filename, range, code, message, hint } = diagnostics;
+			const path = filename.substring(dir.length + 1);
+			const entry = {
+				path,
+				firstLine: range.start.line,
+				lastLine: range.end.line,
+				message: `${removeTrailingPeriod(message)} (${code}, ${hint})`,
+			};
+			lintResult.warning.push(entry);
+		}
+		return lintResult;
+	}
+}
+
+module.exports = DenoLint;

--- a/src/linters/deno-lint.js
+++ b/src/linters/deno-lint.js
@@ -37,15 +37,28 @@ class DenoLint {
 	 * @returns {{status: number, stdout: string, stderr: string}} - Output of the lint command
 	 */
 	static lint(dir, extensions, args = "", fix = false, prefix = "") {
-		if (extensions.length !== 1 || extensions[0] !== "ts") {
-			throw new Error(`${this.name} error: File extensions are not configurable`);
-		}
-
 		if (fix) {
 			core.warning(`${this.name} does not support auto-fixing`);
 		}
 
-		return run(`${prefix} deno lint --json ${args}`, {
+		let targets;
+		switch (extensions.length) {
+			case 0:
+				targets = "";
+				break;
+			case 1:
+				if (extensions[0] === "*") {
+					targets = ""; // all files supported by deno lint
+				} else {
+					targets = `./**/*.${extensions[0]}`;
+				}
+				break;
+			default:
+				targets = `./**/*.{${extensions.map((ext) => ext).join(",")}}`;
+				break;
+		}
+
+		return run(`${prefix} deno lint ${targets} --json ${args}`, {
 			dir,
 			ignoreErrors: true,
 		});

--- a/src/linters/index.js
+++ b/src/linters/index.js
@@ -2,6 +2,7 @@ const Autopep8 = require("./autopep8");
 const Black = require("./black");
 const ClangFormat = require("./clang-format");
 const Clippy = require("./clippy");
+const DenoLint = require("./deno-lint");
 const DotnetFormat = require("./dotnet-format");
 const Erblint = require("./erblint");
 const ESLint = require("./eslint");
@@ -25,6 +26,7 @@ const XO = require("./xo");
 const linters = {
 	// Linters
 	clippy: Clippy,
+	deno_lint: DenoLint,
 	erblint: Erblint,
 	eslint: ESLint,
 	flake8: Flake8,

--- a/test/linters/linters.test.js
+++ b/test/linters/linters.test.js
@@ -7,6 +7,7 @@ const autopep8Params = require("./params/autopep8");
 const blackParams = require("./params/black");
 const clangFormatParams = require("./params/clang-format");
 const clippyParams = require("./params/clippy");
+const denoLintParams = require("./params/deno-lint");
 const dotnetFormatParams = require("./params/dotnet-format");
 const erblintParams = require("./params/erblint");
 const eslintParams = require("./params/eslint");
@@ -32,6 +33,7 @@ const linterParams = [
 	blackParams,
 	clangFormatParams,
 	clippyParams,
+	denoLintParams,
 	dotnetFormatParams,
 	erblintParams,
 	eslintParams,

--- a/test/linters/params/deno-lint.js
+++ b/test/linters/params/deno-lint.js
@@ -1,0 +1,62 @@
+const DenoLint = require("../../../src/linters/deno-lint");
+const { joinDoubleBackslash } = require("../../test-utils");
+
+const testName = "deno-lint";
+const linter = DenoLint;
+const args = "";
+const commandPrefex = "";
+const extensions = ["ts"];
+
+// Linting without auto-fixing
+function getLintParams(dir) {
+	const stdoutStr = `{
+  "diagnostics": [
+    {
+      "range": {
+        "start": {
+          "line": 1,
+          "col": 31,
+          "bytePos": 31
+        },
+        "end": {
+          "line": 1,
+          "col": 35,
+          "bytePos": 35
+        }
+      },
+      "filename": "${joinDoubleBackslash(dir, "file.ts")}",
+      "message": "\`arg1\` is never used",
+      "code": "no-unused-vars",
+      "hint": "If this is intentional, prefix it with an underscore like \`_arg1\`"
+    }
+  ],
+  "errors": []
+}`;
+	return {
+		// Expected output of the linting function
+		cmdOutput: {
+			status: 1,
+			stdOutParts: stdoutStr,
+			stdout: stdoutStr,
+		},
+		// Expected output of the parsing function
+		lintResult: {
+			isSuccess: false,
+			warning: [
+				{
+					firstLine: 1,
+					lastLine: 1,
+					message:
+						"`arg1` is never used (no-unused-vars, If this is intentional, prefix it with an underscore like `_arg1`)",
+					path: "file.ts",
+				},
+			],
+			error: [],
+		},
+	};
+}
+
+// Linting with auto-fixing
+const getFixParams = getLintParams; // Does not support auto-fixing -> option has no effect
+
+module.exports = [testName, linter, commandPrefex, extensions, args, getLintParams, getFixParams];

--- a/test/linters/params/deno-lint.js
+++ b/test/linters/params/deno-lint.js
@@ -5,7 +5,7 @@ const testName = "deno-lint";
 const linter = DenoLint;
 const args = "";
 const commandPrefex = "";
-const extensions = ["ts"];
+const extensions = ["*"];
 
 // Linting without auto-fixing
 function getLintParams(dir) {

--- a/test/linters/projects/deno-lint/file.ts
+++ b/test/linters/projects/deno-lint/file.ts
@@ -1,0 +1,3 @@
+export default function Sample(arg1) {
+	console.log("Hello World");
+}


### PR DESCRIPTION
Hi. I added `deno lint` (the built-in linter of deno runtime) support. 

I would be happy if you could merge this pr!

## resources

- https://docs.deno.com/runtime/manual/tools/linter
  - official documentation of `deno lint`