### PR TITLE
Update link to rubocop docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ _**Note:** The behavior of actions like this one is currently limited in the con
   - [Pylint](https://pylint.pycqa.org)
 - **Ruby:**
   - [ERB Lint](https://github.com/Shopify/erb-lint)
-  - [RuboCop](https://rubocop.readthedocs.io)
+  - [RuboCop](https://docs.rubocop.org/)
 - **Rust:**
   - [clippy](https://github.com/rust-lang/rust-clippy)
   - [rustfmt](https://github.com/rust-lang/rustfmt)


### PR DESCRIPTION
Hi there, I noticed that the `readthedocs.io` link that was here was actually spammy, so I just thought I'd do a drive-by cleanup ^_^

<img width="1030" alt="Screenshot 2025-07-09 at 13 05 56" src="https://github.com/user-attachments/assets/d8b4c175-c4ba-4caf-aa44-d301c187bbf9" />

✌️ 