### PR TITLE
Update linter tests for current toolchains

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "7.4"
+          php-version: "latest"
           coverage: none
           tools: phpcs
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -6823,7 +6823,11 @@ class Black {
 	 */
 	static parseOutput(dir, output) {
 		const lintResult = initLintResult();
-		lintResult.error = parseErrorsFromDiff(output.stdout);
+		lintResult.error = parseErrorsFromDiff(output.stdout).map((error) => ({
+			...error,
+			// Black 23.10+ reports absolute paths in the diff headers, earlier versions relative ones
+			path: error.path.startsWith(dir) ? error.path.substring(dir.length + 1) : error.path,
+		}));
 		lintResult.isSuccess = output.status === 0;
 		return lintResult;
 	}
@@ -8336,7 +8340,9 @@ const { initLintResult } = __nccwpck_require__(9149);
 
 /** @typedef {import('../utils/lint-result').LintResult} LintResult */
 
-const PARSE_REGEX = /([\s\S]*?) at line (\d*):$([\s\S]*)/m;
+// rustfmt used to report diffs as "Diff in <file> at line <line>:", newer versions (1.9+) use
+// "Diff in <file>:<line>:"
+const PARSE_REGEX = /([\s\S]*?)(?: at line |:)(\d+):$([\s\S]*)/m;
 
 /**
  * https://github.com/rust-lang/rustfmt

--- a/src/linters/black.js
+++ b/src/linters/black.js
@@ -59,7 +59,11 @@ class Black {
 	 */
 	static parseOutput(dir, output) {
 		const lintResult = initLintResult();
-		lintResult.error = parseErrorsFromDiff(output.stdout);
+		lintResult.error = parseErrorsFromDiff(output.stdout).map((error) => ({
+			...error,
+			// Black 23.10+ reports absolute paths in the diff headers, earlier versions relative ones
+			path: error.path.startsWith(dir) ? error.path.substring(dir.length + 1) : error.path,
+		}));
 		lintResult.isSuccess = output.status === 0;
 		return lintResult;
 	}

--- a/src/linters/rustfmt.js
+++ b/src/linters/rustfmt.js
@@ -4,7 +4,9 @@ const { initLintResult } = require("../utils/lint-result");
 
 /** @typedef {import('../utils/lint-result').LintResult} LintResult */
 
-const PARSE_REGEX = /([\s\S]*?) at line (\d*):$([\s\S]*)/m;
+// rustfmt used to report diffs as "Diff in <file> at line <line>:", newer versions (1.9+) use
+// "Diff in <file>:<line>:"
+const PARSE_REGEX = /([\s\S]*?)(?: at line |:)(\d+):$([\s\S]*)/m;
 
 /**
  * https://github.com/rust-lang/rustfmt

--- a/test/linters/params/black.js
+++ b/test/linters/params/black.js
@@ -1,3 +1,5 @@
+const { join } = require("path");
+
 const Black = require("../../../src/linters/black");
 const { TEST_DATE } = require("../../test-utils");
 
@@ -9,14 +11,17 @@ const extensions = ["py"];
 
 // Linting without auto-fixing
 function getLintParams(dir) {
-	const stdoutFile1 = `--- file1.py	${TEST_DATE}\n+++ file1.py	${TEST_DATE}\n@@ -1,10 +1,10 @@\n var_1 = "hello"\n var_2 = "world"\n \n \n-def main ():  # Whitespace error\n+def main():  # Whitespace error\n     print("hello " + var_2)\n \n \n def add(num_1, num_2):\n     return num_1 + num_2\n@@ -19,8 +19,9 @@\n \n \n def divide(num_1, num_2):\n     return num_1 / num_2\n \n+\n # Blank lines error\n \n main()`;
-	const stdoutFile2 = `--- file2.py	${TEST_DATE}\n+++ file2.py	${TEST_DATE}\n@@ -1,2 +1,2 @@\n def add(num_1, num_2):\n-  return num_1 + num_2  # Indentation error\n+    return num_1 + num_2  # Indentation error`;
+	// Black 23.10+ reports absolute paths in the diff headers
+	const file1 = join(dir, "file1.py");
+	const file2 = join(dir, "file2.py");
+	const stdoutFile1 = `--- ${file1}	${TEST_DATE}\n+++ ${file1}	${TEST_DATE}\n@@ -1,10 +1,10 @@\n var_1 = "hello"\n var_2 = "world"\n \n \n-def main ():  # Whitespace error\n+def main():  # Whitespace error\n     print("hello " + var_2)\n \n \n def add(num_1, num_2):\n     return num_1 + num_2\n@@ -19,8 +19,9 @@\n \n \n def divide(num_1, num_2):\n     return num_1 / num_2\n \n+\n # Blank lines error\n \n main()`;
+	const stdoutFile2 = `--- ${file2}	${TEST_DATE}\n+++ ${file2}	${TEST_DATE}\n@@ -1,2 +1,2 @@\n def add(num_1, num_2):\n-  return num_1 + num_2  # Indentation error\n+    return num_1 + num_2  # Indentation error`;
 	return {
 		// Expected output of the linting function
 		cmdOutput: {
 			status: 1,
 			stdoutParts: [stdoutFile1, stdoutFile2],
-			stdout: `${stdoutFile1}\n \n${stdoutFile2}`,
+			stdout: `${stdoutFile1}\n${stdoutFile2}`,
 		},
 		// Expected output of the parsing function
 		lintResult: {

--- a/test/linters/params/clippy.js
+++ b/test/linters/params/clippy.js
@@ -9,51 +9,50 @@ const args = "--allow-dirty";
 const commandPrefix = "";
 const extensions = ["rs"];
 
+// Build the JSON lines emitted by `cargo clippy --message-format json`. Note the liblint hash
+// changes based on tooling and what not, so we rely on stdoutParts to make the tests stable
+// across machines
+function getOutputParts(dir) {
+	const srcPath = join("src", "main.rs");
+	const file1 = joinDoubleBackslash("src", "file1.rs");
+	const rmeta = join("target", "debug", "deps", "liblint-5522172e953d5996.rmeta");
+
+	let pathFile = dir;
+	if (process.platform === "win32") {
+		pathFile = `/${dir.replace(/\\/g, "/")}`;
+	}
+
+	const compilerMessage = `{"reason":"compiler-message","package_id":"path+file://${pathFile}#lint@0.0.1","manifest_path":"${joinDoubleBackslash(
+		dir,
+		"Cargo.toml",
+	)}","target":{"kind":["bin"],"crate_types":["bin"],"name":"lint","src_path":"${joinDoubleBackslash(
+		dir,
+		srcPath,
+	)}","edition":"2021","doc":true,"doctest":false,"test":true},"message":{"rendered":"warning: function \`sayHi\` should have a snake case name\\n --> ${file1}:1:8\\n  |\\n1 | pub fn sayHi(name: &str) {\\n  |        ^^^^^ help: convert the identifier to snake case: \`say_hi\`\\n  |\\n  = note: \`#[warn(non_snake_case)]\` (part of \`#[warn(nonstandard_style)]\`) on by default\\n\\n","$message_type":"diagnostic","children":[{"children":[],"code":null,"level":"note","message":"\`#[warn(non_snake_case)]\` (part of \`#[warn(nonstandard_style)]\`) on by default","rendered":null,"spans":[]},{"children":[],"code":null,"level":"help","message":"convert the identifier to snake case","rendered":null,"spans":[{"byte_end":12,"byte_start":7,"column_end":13,"column_start":8,"expansion":null,"file_name":"${file1}","is_primary":true,"label":null,"line_end":1,"line_start":1,"suggested_replacement":"say_hi","suggestion_applicability":"MaybeIncorrect","text":[{"highlight_end":13,"highlight_start":8,"text":"pub fn sayHi(name: &str) {"}]}]}],"level":"warning","message":"function \`sayHi\` should have a snake case name","spans":[{"byte_end":12,"byte_start":7,"column_end":13,"column_start":8,"expansion":null,"file_name":"${file1}","is_primary":true,"label":null,"line_end":1,"line_start":1,"suggested_replacement":null,"suggestion_applicability":null,"text":[{"highlight_end":13,"highlight_start":8,"text":"pub fn sayHi(name: &str) {"}]}],"code":{"code":"non_snake_case","explanation":null}}}\n`;
+	const compilerArtifact = `{"reason":"compiler-artifact","package_id":"path+file://${pathFile}#lint@0.0.1","manifest_path":"${join(
+		dir,
+		"Cargo.toml",
+	)}","target":{"kind":["bin"],"crate_types":["bin"],"name":"lint","src_path":"${join(
+		dir,
+		srcPath,
+	)}","edition":"2021","doc":true,"doctest":false,"test":true},"profile":{"opt_level":"0","debuginfo":2,"debug_assertions":true,"overflow_checks":true,"test":false},"features":[],"filenames":["${join(
+		dir,
+		rmeta,
+	)}"],"executable":null,"fresh":false}\n`;
+	const buildFinished = `{"reason":"build-finished","success":true}`;
+
+	return { compilerMessage, compilerArtifact, buildFinished };
+}
+
 // Linting without auto-fixing
 function getLintParams(dir) {
-	const srcPath = join("src", "main.rs");
-	const file1 = joinDoubleBackslash("src", "file1.rs");
-
-	// Not the liblint hash changes based on tooling and what not, so we rely on
-	// stdoutParts to make the tests stable across machines
-	const rmeta = join("target", "debug", "deps", "liblint-5522172e953d5996.rmeta");
-
-	let pathFile = dir;
-	if (process.platform === "win32") {
-		pathFile = `/${dir.replace(/\\/g, "/")}`;
-	}
-
-	const stderrPart1 = `{"reason":"compiler-message","package_id":"lint 0.0.1 (path+file://${pathFile})","manifest_path":"${joinDoubleBackslash(
-		dir,
-		"Cargo.toml",
-	)}","target":{"kind":["bin"],"crate_types":["bin"],"name":"lint","src_path":"${joinDoubleBackslash(
-		dir,
-		srcPath,
-	)}","edition":"2021","doc":true,"doctest":false,"test":true},"message":{"rendered":"warning: function \`sayHi\` should have a snake case name\\n --> ${file1}:1:8\\n  |\\n1 | pub fn sayHi(name: &str) {\\n  |        ^^^^^ help: convert the identifier to snake case: \`say_hi\`\\n  |\\n  = note: \`#[warn(non_snake_case)]\` on by default\\n\\n","$message_type":"diagnostic","children":[{"children":[],"code":null,"level":"note","message":"\`#[warn(non_snake_case)]\` on by default","rendered":null,"spans":[]},{"children":[],"code":null,"level":"help","message":"convert the identifier to snake case","rendered":null,"spans":[{"byte_end":12,"byte_start":7,"column_end":13,"column_start":8,"expansion":null,"file_name":"${file1}","is_primary":true,"label":null,"line_end":1,"line_start":1,"suggested_replacement":"say_hi","suggestion_applicability":"MaybeIncorrect","text":[{"highlight_end":13,"highlight_start":8,"text":"pub fn sayHi(name: &str) {"}]}]}],"code":{"code":"non_snake_case","explanation":null},"level":"warning","message":"function \`sayHi\` should have a snake case name","spans":[{"byte_end":12,"byte_start":7,"column_end":13,"column_start":8,"expansion":null,"file_name":"${file1}","is_primary":true,"label":null,"line_end":1,"line_start":1,"suggested_replacement":null,"suggestion_applicability":null,"text":[{"highlight_end":13,"highlight_start":8,"text":"pub fn sayHi(name: &str) {"}]}]}}\n`;
-	const stderrPart2 = `{"reason":"compiler-message","package_id":"lint 0.0.1 (path+file://${pathFile})","manifest_path":"${joinDoubleBackslash(
-		dir,
-		"Cargo.toml",
-	)}","target":{"kind":["bin"],"crate_types":["bin"],"name":"lint","src_path":"${joinDoubleBackslash(
-		dir,
-		srcPath,
-	)}","edition":"2021","doc":true,"doctest":false,"test":true},"message":{"rendered":"warning: 1 warning emitted\\n\\n","children":[],"code":null,"level":"warning","message":"1 warning emitted","spans":[]}}\n`;
-	const stderrPart3 = `{"reason":"compiler-artifact","package_id":"lint 0.0.1 (path+file://${dir})","manifest_path":"${join(
-		dir,
-		"Cargo.toml",
-	)}","target":{"kind":["bin"],"crate_types":["bin"],"name":"lint","src_path":"${join(
-		dir,
-		srcPath,
-	)}","edition":"2021","doc":true,"doctest":false,"test":true},"profile":{"opt_level":"0","debuginfo":2,"debug_assertions":true,"overflow_checks":true,"test":false},"features":[],"filenames":["${join(
-		dir,
-		rmeta,
-	)}"],"executable":null,"fresh":false}\n`;
-	const stderrPart4 = `{"reason":"build-finished","success":true}`;
+	const { compilerMessage, compilerArtifact, buildFinished } = getOutputParts(dir);
 	return {
 		// Expected output of the linting function
 		cmdOutput: {
 			status: 0,
-			stdoutParts: [stderrPart1, stderrPart2],
-			stdout: `${stderrPart1}${stderrPart2}${stderrPart3}${stderrPart4}`,
+			stdoutParts: [compilerMessage],
+			stdout: `${compilerMessage}${compilerArtifact}${buildFinished}`,
 		},
 		// Expected output of the parsing function
 		lintResult: {
@@ -71,72 +70,8 @@ function getLintParams(dir) {
 	};
 }
 
-// Linting with auto-fixing
-function getFixParams(dir) {
-	const srcPath = join("src", "main.rs");
-	const file1 = joinDoubleBackslash("src", "file1.rs");
-
-	// Not the liblint hash changes based on tooling and what not, so we rely on
-	// stdoutParts to make the tests stable across machines
-	const rmeta = join("target", "debug", "deps", "liblint-5522172e953d5996.rmeta");
-
-	let pathFile = dir;
-	if (process.platform === "win32") {
-		pathFile = `/${dir.replace(/\\/g, "/")}`;
-	}
-
-	const stderrPart1 = `{"reason":"compiler-message","package_id":"lint 0.0.1 (path+file://${pathFile})","manifest_path":"${joinDoubleBackslash(
-		dir,
-		"Cargo.toml",
-	)}","target":{"kind":["bin"],"crate_types":["bin"],"name":"lint","src_path":"${joinDoubleBackslash(
-		dir,
-		srcPath,
-	)}","edition":"2021","doc":true,"doctest":false,"test":true},"message":{"rendered":"warning: function \`sayHi\` should have a snake case name\\n --> ${file1}:1:8\\n  |\\n1 | pub fn sayHi(name: &str) {\\n  |        ^^^^^ help: convert the identifier to snake case: \`say_hi\`\\n  |\\n  = note: \`#[warn(non_snake_case)]\` on by default\\n\\n","$message_type":"diagnostic","children":[{"children":[],"code":null,"level":"note","message":"\`#[warn(non_snake_case)]\` on by default","rendered":null,"spans":[]},{"children":[],"code":null,"level":"help","message":"convert the identifier to snake case","rendered":null,"spans":[{"byte_end":12,"byte_start":7,"column_end":13,"column_start":8,"expansion":null,"file_name":"${file1}","is_primary":true,"label":null,"line_end":1,"line_start":1,"suggested_replacement":"say_hi","suggestion_applicability":"MaybeIncorrect","text":[{"highlight_end":13,"highlight_start":8,"text":"pub fn sayHi(name: &str) {"}]}]}],"code":{"code":"non_snake_case","explanation":null},"level":"warning","message":"function \`sayHi\` should have a snake case name","spans":[{"byte_end":12,"byte_start":7,"column_end":13,"column_start":8,"expansion":null,"file_name":"${file1}","is_primary":true,"label":null,"line_end":1,"line_start":1,"suggested_replacement":null,"suggestion_applicability":null,"text":[{"highlight_end":13,"highlight_start":8,"text":"pub fn sayHi(name: &str) {"}]}]}}\n`;
-	const stderrPart2 = `{"reason":"compiler-message","package_id":"lint 0.0.1 (path+file://${pathFile})","manifest_path":"${joinDoubleBackslash(
-		dir,
-		"Cargo.toml",
-	)}","target":{"kind":["bin"],"crate_types":["bin"],"name":"lint","src_path":"${joinDoubleBackslash(
-		dir,
-		srcPath,
-	)}","edition":"2021","doc":true,"doctest":false,"test":true},"message":{"rendered":"warning: 1 warning emitted\\n\\n","children":[],"code":null,"level":"warning","message":"1 warning emitted","spans":[]}}\n`;
-	const stderrPart3 = `{"reason":"compiler-artifact","package_id":"lint 0.0.1 (path+file://${dir})","manifest_path":"${join(
-		dir,
-		"Cargo.toml",
-	)}","target":{"kind":["bin"],"crate_types":["bin"],"name":"lint","src_path":"${join(
-		dir,
-		srcPath,
-	)}","edition":"2021","doc":true,"doctest":false,"test":true},"profile":{"opt_level":"0","debuginfo":2,"debug_assertions":true,"overflow_checks":true,"test":false},"features":[],"filenames":["${join(
-		dir,
-		rmeta,
-	)}"],"executable":null,"fresh":false}\n`;
-	const stderrPart4 = `{"reason":"build-finished","success":true}`;
-	return {
-		// Expected output of the linting function
-		cmdOutput: {
-			status: 0,
-			stdoutParts: [stderrPart1, stderrPart2],
-			stdout: `${stderrPart1}${stderrPart2}${stderrPart3}${stderrPart1}${stderrPart2}${stderrPart3}${stderrPart4}`,
-		},
-		// Expected output of the parsing function
-		lintResult: {
-			isSuccess: false,
-			warning: [
-				{
-					path: joinDoubleBackslash("src", "file1.rs"),
-					firstLine: 1,
-					lastLine: 1,
-					message: "function `sayHi` should have a snake case name",
-				},
-				{
-					path: joinDoubleBackslash("src", "file1.rs"),
-					firstLine: 1,
-					lastLine: 1,
-					message: "function `sayHi` should have a snake case name",
-				},
-			],
-			error: [],
-		},
-	};
-}
+// Linting with auto-fixing. The `non_snake_case` warning cannot be fixed automatically, so the
+// output matches the lint mode
+const getFixParams = getLintParams;
 
 module.exports = [testName, linter, commandPrefix, extensions, args, getLintParams, getFixParams];

--- a/test/linters/params/php-codesniffer.js
+++ b/test/linters/params/php-codesniffer.js
@@ -18,11 +18,11 @@ function getLintParams(dir) {
 	return {
 		// Expected output of the linting function
 		cmdOutput: {
-			// PHP_CodeSniffer exit codes:
-			// - 0: No errors found.
-			// - 1: Errors found, but none of them can be fixed by PHPCBF.
-			// - 2: Errors found, and some can be fixed by PHPCBF.
-			status: 2,
+			// PHP_CodeSniffer 4 exit codes are a bitmask:
+			// - Bit 0: Issues found which PHPCBF cannot fix.
+			// - Bit 1: Issues found which PHPCBF can fix.
+			// The test project contains a non-fixable warning and two fixable errors -> 3.
+			status: 3,
 			stdoutParts: [stdoutFile1, stdoutFile2],
 			stdout,
 		},

--- a/test/linters/params/rustfmt.js
+++ b/test/linters/params/rustfmt.js
@@ -19,12 +19,12 @@ function getLintParams(dir) {
 		localDir,
 		"src",
 		"foo.rs",
-	)} at line 2:\n //!\n //!\n //! This should push the error start line down past 1\n-use std::time::{SystemTime, Duration};\n+use std::time::{Duration, SystemTime};\n \n pub fn delta() -> Duration {\n-        let start = SystemTime::now(); let delta = start.elapsed().unwrap();\n-        delta\n+    let start = SystemTime::now();\n+    let delta = start.elapsed().unwrap();\n+    delta\n }\n `;
+	)}:2:\n //!\n //!\n //! This should push the error start line down past 1\n-use std::time::{SystemTime, Duration};\n+use std::time::{Duration, SystemTime};\n \n pub fn delta() -> Duration {\n-        let start = SystemTime::now(); let delta = start.elapsed().unwrap();\n-        delta\n+    let start = SystemTime::now();\n+    let delta = start.elapsed().unwrap();\n+    delta\n }\n `;
 	const stdoutFile2 = `Diff in ${join(
 		localDir,
 		"src",
 		"main.rs",
-	)} at line 1:\n mod foo;\n-fn main() {let delta = foo::delta(); println!("Time delta is {delta:?}");}\n+fn main() {\n+    let delta = foo::delta();\n+    println!("Time delta is {delta:?}");\n+}`;
+	)}:1:\n mod foo;\n-fn main() {let delta = foo::delta(); println!("Time delta is {delta:?}");}\n+fn main() {\n+    let delta = foo::delta();\n+    println!("Time delta is {delta:?}");\n+}`;
 	return {
 		// Expected output of the linting function
 		cmdOutput: {


### PR DESCRIPTION
The `Test` workflow installs the latest versions of the Rust toolchain (`dtolnay/rust-toolchain@stable`), PHP_CodeSniffer (`setup-php` with `tools: phpcs`) and Black (unpinned in `requirements.txt`). Their output has drifted from the expected test outputs over time, which is why `Run tests` fails on master for `black`, `clippy`, `php-codesniffer` and `rustfmt` (see the run for #995).

## Runner fixes (real bugs with current toolchains, not just tests)

* **rustfmt**: newer versions report diffs as `Diff in <file>:<line>:` instead of `Diff in <file> at line <line>:`. The old `PARSE_REGEX` doesn't match anymore, so `parseOutput` crashed with a TypeError. The regex now supports both formats.
* **Black**: since 23.10 the `--diff` headers contain absolute paths. `parseOutput` now strips the directory prefix so check annotations keep repo-relative paths (relative paths from older versions keep working).

`dist/` is rebuilt accordingly.

## Test updates

* **clippy**: Cargo changed the `package_id` format to `path+file://<dir>#lint@0.0.1`, rustc extended the `non_snake_case` note (`part of nonstandard_style`), moved the `code` key behind `spans`, no longer emits the `1 warning emitted` summary as a JSON message, and `clippy --fix` compiles only once — lint and auto-fix expectations are identical now.
* **php-codesniffer**: PHP_CodeSniffer 4 uses bitmask exit codes (bit 0 = non-fixable, bit 1 = fixable issues → 3 for the test project). The JSON report format is unchanged. PHP itself is bumped from the EOL 7.4 to `latest` (verified locally with PHP 8.5 + phpcs 4.0.1).
* **black/rustfmt**: golden outputs updated to the current formats.

All 16 affected tests verified locally against Rust 1.97.1, Black 26.5.1 and PHP_CodeSniffer 4.0.1, plus regression runs for stylelint, clang-format and the unit test suites.

## Out of scope

Python (3.8), Go (1.19.4) and .NET (6.0) remain pinned — their linters currently pass; unpinning flake8/pylint would require regenerating their golden outputs and belongs in a separate change. The macOS Ruby 2.7.7/ERB Lint failure is addressed in a follow-up PR.