### PR TITLE
Fix checking out the branch when it is already checked out

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -59,3 +59,39 @@ jobs:
           prettier: true
           prettier_extensions: "css,html,js,json,jsx,less,md,scss,ts,tsx,vue,yaml,yml"
           neutral_check_on_warning: true
+
+  test-checked-out-branch:
+    name: Run action (checked-out branch)
+    # The action switches to the PR branch itself. Checking out the branch here (instead of the
+    # detached SHA above) covers the case where the branch is already checked out, which used to
+    # fail with "cannot force update the current branch". Fork branches do not exist on origin,
+    # so this job only runs for pull requests from the same repository.
+    if: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: ".nvmrc"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build action
+        run: yarn build
+
+      - name: Run linters
+        uses: ./
+        with:
+          continue_on_error: false
+          eslint: true
+          prettier: true
+          prettier_extensions: "css,html,js,json,jsx,less,md,scss,ts,tsx,vue,yaml,yml"
+          neutral_check_on_warning: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -35074,14 +35074,18 @@ function checkOutRemoteBranch(context) {
 
 	const remote = context.repository.hasFork ? "fork" : "origin";
 
-	// Fetch remote branch
+	// Fetch remote branch. The explicit refspec makes sure the remote-tracking branch is created,
+	// the Checkout Action configures a fetch refspec which only covers the ref it checked out
 	core.info(`Fetching remote branch "${context.branch}"`);
-	run(`git fetch --no-tags --depth=1 ${remote} ${context.branch}`);
+	run(
+		`git fetch --no-tags --depth=1 ${remote} ${context.branch}:refs/remotes/${remote}/${context.branch}`,
+	);
 
-	// Switch to remote branch
+	// Switch to remote branch. Unlike `git branch --force`, `git checkout -B` also works when the
+	// branch is already checked out. The fully qualified ref works independently of the fetch
+	// refspec configured by the Checkout Action
 	core.info(`Switching to the "${context.branch}" branch`);
-	run(`git branch --force ${context.branch} --track ${remote}/${context.branch}`);
-	run(`git checkout ${context.branch}`);
+	run(`git checkout --force -B ${context.branch} refs/remotes/${remote}/${context.branch}`);
 }
 
 /**
@@ -35117,11 +35121,16 @@ function hasChanges() {
 
 /**
  * Pushes all changes to the remote repository
+ * @param {GithubContext} context - Information about the GitHub repository
  * @param {boolean} skipVerification - Skip Git verification
  */
-function pushChanges(skipVerification) {
+function pushChanges(context, skipVerification) {
 	core.info("Pushing changes with Git");
-	run(`git push${skipVerification ? " --no-verify" : ""}`);
+	const remote = context.repository.hasFork ? "fork" : "origin";
+	// The explicit refspec makes the push work without a configured upstream
+	run(
+		`git push${skipVerification ? " --no-verify" : ""} ${remote} HEAD:refs/heads/${context.branch}`,
+	);
 }
 
 /**
@@ -40014,7 +40023,7 @@ async function runAction() {
 				// Commit and push auto-fix changes
 				if (git.hasChanges()) {
 					git.commitChanges(commitMessage.replace(/\${linter}/g, linter.name), skipVerification);
-					git.pushChanges(skipVerification);
+					git.pushChanges(context, skipVerification);
 				}
 			}
 

--- a/src/git.js
+++ b/src/git.js
@@ -27,14 +27,18 @@ function checkOutRemoteBranch(context) {
 
 	const remote = context.repository.hasFork ? "fork" : "origin";
 
-	// Fetch remote branch
+	// Fetch remote branch. The explicit refspec makes sure the remote-tracking branch is created,
+	// the Checkout Action configures a fetch refspec which only covers the ref it checked out
 	core.info(`Fetching remote branch "${context.branch}"`);
-	run(`git fetch --no-tags --depth=1 ${remote} ${context.branch}`);
+	run(
+		`git fetch --no-tags --depth=1 ${remote} ${context.branch}:refs/remotes/${remote}/${context.branch}`,
+	);
 
-	// Switch to remote branch
+	// Switch to remote branch. Unlike `git branch --force`, `git checkout -B` also works when the
+	// branch is already checked out. The fully qualified ref works independently of the fetch
+	// refspec configured by the Checkout Action
 	core.info(`Switching to the "${context.branch}" branch`);
-	run(`git branch --force ${context.branch} --track ${remote}/${context.branch}`);
-	run(`git checkout ${context.branch}`);
+	run(`git checkout --force -B ${context.branch} refs/remotes/${remote}/${context.branch}`);
 }
 
 /**
@@ -70,11 +74,16 @@ function hasChanges() {
 
 /**
  * Pushes all changes to the remote repository
+ * @param {GithubContext} context - Information about the GitHub repository
  * @param {boolean} skipVerification - Skip Git verification
  */
-function pushChanges(skipVerification) {
+function pushChanges(context, skipVerification) {
 	core.info("Pushing changes with Git");
-	run(`git push${skipVerification ? " --no-verify" : ""}`);
+	const remote = context.repository.hasFork ? "fork" : "origin";
+	// The explicit refspec makes the push work without a configured upstream
+	run(
+		`git push${skipVerification ? " --no-verify" : ""} ${remote} HEAD:refs/heads/${context.branch}`,
+	);
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -108,7 +108,7 @@ async function runAction() {
 				// Commit and push auto-fix changes
 				if (git.hasChanges()) {
 					git.commitChanges(commitMessage.replace(/\${linter}/g, linter.name), skipVerification);
-					git.pushChanges(skipVerification);
+					git.pushChanges(context, skipVerification);
 				}
 			}
 

--- a/test/linters/projects/erblint/.bundle/config
+++ b/test/linters/projects/erblint/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor/bundle"

--- a/test/linters/projects/rubocop/.bundle/config
+++ b/test/linters/projects/rubocop/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor/bundle"


### PR DESCRIPTION
Supersedes #205 (credited via `Co-authored-by`), fixes #193.

## Problem

`checkOutRemoteBranch()` runs on every pull request event and fails in two scenarios:

1. **Branch already checked out** (`fatal: cannot force update the current branch`): happens when a workflow checks out the PR branch (`ref: github.head_ref`) instead of the detached merge commit — the scenario reported in #205.
2. **Missing remote-tracking branch** (`error: the requested upstream branch 'origin/x' does not exist`): the Checkout Action configures a fetch refspec that only covers the ref it checked out, in which case `git fetch <remote> <branch>` does not create tracking branches opportunistically — the scenario reported in #193.

## Fix

* Fetch with an **explicit refspec** (`branch:refs/remotes/<remote>/<branch>`), so the tracking ref is always created regardless of the configured refspec.
* Switch with `git checkout --force -B <branch> refs/remotes/<remote>/<branch>` — works when the branch is already checked out, and the fully qualified ref avoids both dwim ambiguity and refspec mapping issues.
* Push with an **explicit refspec** (`git push <remote> HEAD:refs/heads/<branch>`) instead of relying on a configured upstream. (#205's approach dropped `--track` without replacing the upstream the bare `git push` depended on; `--track` itself fails with the Checkout Action's narrow refspec because the tracking ref can't be mapped back to a remote branch.)

All three commands were verified against scratch repositories simulating the Checkout Action's narrow fetch refspec, the already-checked-out branch, and an upstream-less push.

## CI coverage

The previously failing scenario was never exercised in CI (the existing job checks out the detached `head.sha`). A new **"Run action (checked-out branch)"** job in the Test Action workflow checks out the PR branch itself and runs the action — on the old code this job fails with "cannot force update the current branch"; with this PR it passes. It only runs for same-repository PRs, since fork branches don't exist on origin.

`dist/` is rebuilt.

https://claude.ai/code/session_01Juz45nWDAFudLx8dYBHc73