### PR TITLE
Document the required ERB Lint version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ _**Note:** The behavior of actions like this one is currently limited in the con
   - [oitnb](https://pypi.org/project/oitnb/)
   - [Pylint](https://pylint.pycqa.org)
 - **Ruby:**
-  - [ERB Lint](https://github.com/Shopify/erb-lint)
+  - [ERB Lint](https://github.com/Shopify/erb-lint) (requires erb_lint v0.7.0 or later)
   - [RuboCop](https://rubocop.readthedocs.io)
 - **Rust:**
   - [clippy](https://github.com/rust-lang/rust-clippy)


### PR DESCRIPTION
The action calls the `erb_lint` executable (since #997), which exists as of erb_lint v0.7.0 — document that requirement in the linter list.

This PR also exercises the new "Run action (checked-out branch)" job from #1000 for the first time (pull_request_target workflows run with the master definition, so the job could not run on #1000 itself).

https://claude.ai/code/session_01Juz45nWDAFudLx8dYBHc73