### PR TITLE
Quote attacker-controlled values in shell commands

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -35048,6 +35048,7 @@ function wrappy (fn, cb) {
 const core = __nccwpck_require__(7484);
 
 const { run } = __nccwpck_require__(8597);
+const { shescape } = __nccwpck_require__(5899);
 
 /** @typedef {import('./github/context').GithubContext} GithubContext */
 
@@ -35062,30 +35063,30 @@ function checkOutRemoteBranch(context) {
 		const cloneURl = new URL(context.repository.forkCloneUrl);
 		cloneURl.username = context.actor;
 		cloneURl.password = context.token;
-		run(`git remote add fork ${cloneURl.toString()}`);
+		run(`git remote add fork ${shescape.quote(cloneURl.toString())}`);
 	} else {
 		// No fork: Update remote URL to include auth information (so auto-fixes can be pushed)
 		core.info(`Adding auth information to Git remote URL`);
 		const cloneURl = new URL(context.repository.cloneUrl);
 		cloneURl.username = context.actor;
 		cloneURl.password = context.token;
-		run(`git remote set-url origin ${cloneURl.toString()}`);
+		run(`git remote set-url origin ${shescape.quote(cloneURl.toString())}`);
 	}
 
 	const remote = context.repository.hasFork ? "fork" : "origin";
+	const trackingRef = `refs/remotes/${remote}/${context.branch}`;
 
 	// Fetch remote branch. The explicit refspec makes sure the remote-tracking branch is created,
-	// the Checkout Action configures a fetch refspec which only covers the ref it checked out
+	// the Checkout Action configures a fetch refspec which only covers the ref it checked out.
+	// `context.branch` is attacker-controlled (fork PR head ref), so it must be quoted
 	core.info(`Fetching remote branch "${context.branch}"`);
-	run(
-		`git fetch --no-tags --depth=1 ${remote} ${context.branch}:refs/remotes/${remote}/${context.branch}`,
-	);
+	run(`git fetch --no-tags --depth=1 ${remote} ${shescape.quote(`${context.branch}:${trackingRef}`)}`);
 
 	// Switch to remote branch. Unlike `git branch --force`, `git checkout -B` also works when the
 	// branch is already checked out. The fully qualified ref works independently of the fetch
 	// refspec configured by the Checkout Action
 	core.info(`Switching to the "${context.branch}" branch`);
-	run(`git checkout --force -B ${context.branch} refs/remotes/${remote}/${context.branch}`);
+	run(`git checkout --force -B ${shescape.quote(context.branch)} ${shescape.quote(trackingRef)}`);
 }
 
 /**
@@ -35095,7 +35096,7 @@ function checkOutRemoteBranch(context) {
  */
 function commitChanges(message, skipVerification) {
 	core.info(`Committing changes`);
-	run(`git commit -am "${message}"${skipVerification ? " --no-verify" : ""}`);
+	run(`git commit -am ${shescape.quote(message)}${skipVerification ? " --no-verify" : ""}`);
 }
 
 /**
@@ -35129,7 +35130,9 @@ function pushChanges(context, skipVerification) {
 	const remote = context.repository.hasFork ? "fork" : "origin";
 	// The explicit refspec makes the push work without a configured upstream
 	run(
-		`git push${skipVerification ? " --no-verify" : ""} ${remote} HEAD:refs/heads/${context.branch}`,
+		`git push${skipVerification ? " --no-verify" : ""} ${remote} ${shescape.quote(
+			`HEAD:refs/heads/${context.branch}`,
+		)}`,
 	);
 }
 
@@ -35140,8 +35143,8 @@ function pushChanges(context, skipVerification) {
  */
 function setUserInfo(name, email) {
 	core.info(`Setting Git user information`);
-	run(`git config --global user.name "${name}"`);
-	run(`git config --global user.email "${email}"`);
+	run(`git config --global user.name ${shescape.quote(name)}`);
+	run(`git config --global user.email ${shescape.quote(email)}`);
 }
 
 module.exports = {
@@ -35576,16 +35579,11 @@ module.exports = Black;
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 const glob = __nccwpck_require__(3574);
-const { Shescape } = __nccwpck_require__(3300);
 
 const { run } = __nccwpck_require__(8597);
 const commandExists = __nccwpck_require__(6339);
 const { initLintResult } = __nccwpck_require__(5066);
-
-// `run` executes commands through the default system shell (`execSync`): `cmd.exe` on Windows and
-// `/bin/sh` elsewhere ("bash" quoting is valid for any POSIX sh). Do not destructure the methods,
-// they rely on `this` being the instance.
-const shescape = new Shescape({ shell: process.platform === "win32" ? "cmd.exe" : "bash" });
+const { shescape } = __nccwpck_require__(5899);
 
 /** @typedef {import('../utils/lint-result').LintResult} LintResult */
 
@@ -37985,6 +37983,23 @@ function request(url, options) {
 }
 
 module.exports = request;
+
+
+/***/ }),
+
+/***/ 5899:
+/***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
+
+const { Shescape } = __nccwpck_require__(3300);
+
+// Quoting for the shell used by `run`/`execSync`: `cmd.exe` on Windows and `/bin/sh` elsewhere
+// ("bash" quoting is valid for any POSIX sh). Used to escape values that end up in shell commands,
+// most importantly attacker-controlled ones like the branch name of a fork pull request.
+//
+// Do not destructure the instance methods, they rely on `this` being the instance.
+const shescape = new Shescape({ shell: process.platform === "win32" ? "cmd.exe" : "bash" });
+
+module.exports = { shescape };
 
 
 /***/ }),

--- a/src/git.js
+++ b/src/git.js
@@ -1,6 +1,7 @@
 const core = require("@actions/core");
 
 const { run } = require("./utils/action");
+const { shescape } = require("./utils/shescape");
 
 /** @typedef {import('./github/context').GithubContext} GithubContext */
 
@@ -15,30 +16,32 @@ function checkOutRemoteBranch(context) {
 		const cloneURl = new URL(context.repository.forkCloneUrl);
 		cloneURl.username = context.actor;
 		cloneURl.password = context.token;
-		run(`git remote add fork ${cloneURl.toString()}`);
+		run(`git remote add fork ${shescape.quote(cloneURl.toString())}`);
 	} else {
 		// No fork: Update remote URL to include auth information (so auto-fixes can be pushed)
 		core.info(`Adding auth information to Git remote URL`);
 		const cloneURl = new URL(context.repository.cloneUrl);
 		cloneURl.username = context.actor;
 		cloneURl.password = context.token;
-		run(`git remote set-url origin ${cloneURl.toString()}`);
+		run(`git remote set-url origin ${shescape.quote(cloneURl.toString())}`);
 	}
 
 	const remote = context.repository.hasFork ? "fork" : "origin";
+	const trackingRef = `refs/remotes/${remote}/${context.branch}`;
 
 	// Fetch remote branch. The explicit refspec makes sure the remote-tracking branch is created,
-	// the Checkout Action configures a fetch refspec which only covers the ref it checked out
+	// the Checkout Action configures a fetch refspec which only covers the ref it checked out.
+	// `context.branch` is attacker-controlled (fork PR head ref), so it must be quoted
 	core.info(`Fetching remote branch "${context.branch}"`);
 	run(
-		`git fetch --no-tags --depth=1 ${remote} ${context.branch}:refs/remotes/${remote}/${context.branch}`,
+		`git fetch --no-tags --depth=1 ${remote} ${shescape.quote(`${context.branch}:${trackingRef}`)}`,
 	);
 
 	// Switch to remote branch. Unlike `git branch --force`, `git checkout -B` also works when the
 	// branch is already checked out. The fully qualified ref works independently of the fetch
 	// refspec configured by the Checkout Action
 	core.info(`Switching to the "${context.branch}" branch`);
-	run(`git checkout --force -B ${context.branch} refs/remotes/${remote}/${context.branch}`);
+	run(`git checkout --force -B ${shescape.quote(context.branch)} ${shescape.quote(trackingRef)}`);
 }
 
 /**
@@ -48,7 +51,7 @@ function checkOutRemoteBranch(context) {
  */
 function commitChanges(message, skipVerification) {
 	core.info(`Committing changes`);
-	run(`git commit -am "${message}"${skipVerification ? " --no-verify" : ""}`);
+	run(`git commit -am ${shescape.quote(message)}${skipVerification ? " --no-verify" : ""}`);
 }
 
 /**
@@ -82,7 +85,9 @@ function pushChanges(context, skipVerification) {
 	const remote = context.repository.hasFork ? "fork" : "origin";
 	// The explicit refspec makes the push work without a configured upstream
 	run(
-		`git push${skipVerification ? " --no-verify" : ""} ${remote} HEAD:refs/heads/${context.branch}`,
+		`git push${skipVerification ? " --no-verify" : ""} ${remote} ${shescape.quote(
+			`HEAD:refs/heads/${context.branch}`,
+		)}`,
 	);
 }
 
@@ -93,8 +98,8 @@ function pushChanges(context, skipVerification) {
  */
 function setUserInfo(name, email) {
 	core.info(`Setting Git user information`);
-	run(`git config --global user.name "${name}"`);
-	run(`git config --global user.email "${email}"`);
+	run(`git config --global user.name ${shescape.quote(name)}`);
+	run(`git config --global user.email ${shescape.quote(email)}`);
 }
 
 module.exports = {

--- a/src/linters/clang-format.js
+++ b/src/linters/clang-format.js
@@ -1,14 +1,9 @@
 const glob = require("glob");
-const { Shescape } = require("shescape");
 
 const { run } = require("../utils/action");
 const commandExists = require("../utils/command-exists");
 const { initLintResult } = require("../utils/lint-result");
-
-// `run` executes commands through the default system shell (`execSync`): `cmd.exe` on Windows and
-// `/bin/sh` elsewhere ("bash" quoting is valid for any POSIX sh). Do not destructure the methods,
-// they rely on `this` being the instance.
-const shescape = new Shescape({ shell: process.platform === "win32" ? "cmd.exe" : "bash" });
+const { shescape } = require("../utils/shescape");
 
 /** @typedef {import('../utils/lint-result').LintResult} LintResult */
 

--- a/src/utils/shescape.js
+++ b/src/utils/shescape.js
@@ -1,0 +1,10 @@
+const { Shescape } = require("shescape");
+
+// Quoting for the shell used by `run`/`execSync`: `cmd.exe` on Windows and `/bin/sh` elsewhere
+// ("bash" quoting is valid for any POSIX sh). Used to escape values that end up in shell commands,
+// most importantly attacker-controlled ones like the branch name of a fork pull request.
+//
+// Do not destructure the instance methods, they rely on `this` being the instance.
+const shescape = new Shescape({ shell: process.platform === "win32" ? "cmd.exe" : "bash" });
+
+module.exports = { shescape };

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -5,21 +5,38 @@ const { shescape } = require("../src/utils/shescape");
 jest.mock("../src/utils/action");
 
 /**
- * Builds a GitHub context object for a pull request from the same repository
- * @param {string} branch - Branch name
+ * Builds a GitHub context object for a pull request
+ * @param {object} [options] - Options
+ * @param {string} [options.branch] - Branch name
+ * @param {boolean} [options.hasFork] - Whether the pull request comes from a fork
  * @returns {object} - Context object accepted by the git helpers
  */
-function contextForBranch(branch) {
+function makeContext({ branch = "main", hasFork = false } = {}) {
 	return {
 		actor: "octocat",
 		token: "secret-token",
 		branch,
 		repository: {
-			hasFork: false,
+			hasFork,
 			repoName: "owner/repo",
 			cloneUrl: "https://github.com/owner/repo.git",
+			forkName: hasFork ? "forker/repo" : undefined,
+			forkCloneUrl: hasFork ? "https://github.com/forker/repo.git" : undefined,
 		},
 	};
+}
+
+/**
+ * Builds the auth-carrying remote URL exactly like `checkOutRemoteBranch` does
+ * @param {string} cloneUrl - Clone URL of the repository
+ * @param {object} context - Context object the git helper receives
+ * @returns {string} - Remote URL with the actor and token embedded
+ */
+function authRemoteUrl(cloneUrl, context) {
+	const url = new URL(cloneUrl);
+	url.username = context.actor;
+	url.password = context.token;
+	return url.toString();
 }
 
 // A branch name is fully attacker-controlled for pull requests from a fork (the head ref). Git
@@ -34,7 +51,7 @@ describe("git command injection", () => {
 	});
 
 	test("checkOutRemoteBranch quotes the branch name and refspecs", () => {
-		git.checkOutRemoteBranch(contextForBranch(MALICIOUS_BRANCH));
+		git.checkOutRemoteBranch(makeContext({ branch: MALICIOUS_BRANCH }));
 		const commands = run.mock.calls.map((call) => call[0]);
 		const trackingRef = `refs/remotes/origin/${MALICIOUS_BRANCH}`;
 
@@ -48,8 +65,26 @@ describe("git command injection", () => {
 		expect(checkoutCmd).toContain(shescape.quote(trackingRef));
 	});
 
+	test("checkOutRemoteBranch quotes the auth-carrying origin remote URL", () => {
+		const context = makeContext({ hasFork: false });
+		git.checkOutRemoteBranch(context);
+		const cmd = run.mock.calls
+			.map((call) => call[0])
+			.find((c) => c.startsWith("git remote set-url origin"));
+		expect(cmd).toContain(shescape.quote(authRemoteUrl(context.repository.cloneUrl, context)));
+	});
+
+	test("checkOutRemoteBranch quotes the auth-carrying fork remote URL", () => {
+		const context = makeContext({ hasFork: true });
+		git.checkOutRemoteBranch(context);
+		const cmd = run.mock.calls
+			.map((call) => call[0])
+			.find((c) => c.startsWith("git remote add fork"));
+		expect(cmd).toContain(shescape.quote(authRemoteUrl(context.repository.forkCloneUrl, context)));
+	});
+
 	test("pushChanges quotes the refspec built from the branch name", () => {
-		git.pushChanges(contextForBranch(MALICIOUS_BRANCH), false);
+		git.pushChanges(makeContext({ branch: MALICIOUS_BRANCH }), false);
 		const cmd = run.mock.calls[0][0];
 		expect(cmd).toContain(shescape.quote(`HEAD:refs/heads/${MALICIOUS_BRANCH}`));
 	});

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -1,0 +1,63 @@
+const git = require("../src/git");
+const { run } = require("../src/utils/action");
+const { shescape } = require("../src/utils/shescape");
+
+jest.mock("../src/utils/action");
+
+/**
+ * Builds a GitHub context object for a pull request from the same repository
+ * @param {string} branch - Branch name
+ * @returns {object} - Context object accepted by the git helpers
+ */
+function contextForBranch(branch) {
+	return {
+		actor: "octocat",
+		token: "secret-token",
+		branch,
+		repository: {
+			hasFork: false,
+			repoName: "owner/repo",
+			cloneUrl: "https://github.com/owner/repo.git",
+		},
+	};
+}
+
+// A branch name is fully attacker-controlled for pull requests from a fork (the head ref). Git
+// allows characters like `$`, backticks, `(`, `)` and `;` in ref names, so an unquoted
+// interpolation into a shell command would allow command injection. The single quote is included
+// to exercise shescape's escaping of the quote character itself.
+const MALICIOUS_BRANCH = "x$(touch /tmp/pwned)`whoami`;echo'rm";
+
+describe("git command injection", () => {
+	beforeEach(() => {
+		run.mockClear();
+	});
+
+	test("checkOutRemoteBranch quotes the branch name and refspecs", () => {
+		git.checkOutRemoteBranch(contextForBranch(MALICIOUS_BRANCH));
+		const commands = run.mock.calls.map((call) => call[0]);
+		const trackingRef = `refs/remotes/origin/${MALICIOUS_BRANCH}`;
+
+		// shescape output depends on the platform's shell, so compare against `shescape.quote`
+		// rather than a hardcoded escaping
+		const fetchCmd = commands.find((cmd) => cmd.startsWith("git fetch"));
+		expect(fetchCmd).toContain(shescape.quote(`${MALICIOUS_BRANCH}:${trackingRef}`));
+
+		const checkoutCmd = commands.find((cmd) => cmd.startsWith("git checkout"));
+		expect(checkoutCmd).toContain(shescape.quote(MALICIOUS_BRANCH));
+		expect(checkoutCmd).toContain(shescape.quote(trackingRef));
+	});
+
+	test("pushChanges quotes the refspec built from the branch name", () => {
+		git.pushChanges(contextForBranch(MALICIOUS_BRANCH), false);
+		const cmd = run.mock.calls[0][0];
+		expect(cmd).toContain(shescape.quote(`HEAD:refs/heads/${MALICIOUS_BRANCH}`));
+	});
+
+	test("commitChanges quotes the commit message", () => {
+		const message = 'msg"; rm -rf / #';
+		git.commitChanges(message, false);
+		const cmd = run.mock.calls[0][0];
+		expect(cmd).toContain(shescape.quote(message));
+	});
+});


### PR DESCRIPTION
## Security issue

`context.branch` is `event.pull_request.head.ref` — **fully attacker-controlled** for pull requests from a fork. Git ref names may contain `$`, backticks, `(`, `)`, `;` and more, and `git.js` interpolated the branch name unquoted into shell commands executed via `execSync`. On a `pull_request_target` workflow (the setup this action documents for fork PRs) that runs with the **base repository's token and secrets**, so a fork PR with a branch name like ``x`whoami` `` or `x$(…)` achieves command injection.

Reproduced locally:

```
branch = "x$(touch …/PWNED)"
execSync(`git checkout --force -B ${branch} …`)   →  PWNED created
execSync(`git checkout --force -B ${shescape.quote(branch)} …`)  →  no injection
```

## Fix

* Extract the `Shescape` instance already used by `clang-format.js` into a shared `src/utils/shescape.js` (configured for the shell `execSync` actually uses — `cmd.exe` on Windows, POSIX sh elsewhere).
* Quote every interpolated value in `git.js`: branch name, fetch/checkout/push refspecs, commit message, user name/email, and the auth-carrying remote URL.
* `clang-format.js` now imports the shared instance instead of creating its own (no behavior change).

## Tests

New `test/git.test.js` mocks `run` and asserts a malicious branch name / commit message reaches the shell only in shescape-escaped form (the payload includes a `'` to exercise quote escaping). Existing clang-format fixtures still pass.

`dist/` is rebuilt.