### PR TITLE
Make the commandExists test reliable on Windows

### DIFF
--- a/test/utils/command-exists.test.js
+++ b/test/utils/command-exists.test.js
@@ -1,8 +1,14 @@
 const commandExists = require("../../src/utils/command-exists");
 
+// `command-exists` shells out to `where`/`command -v`, which can be slow to spawn on a loaded
+// (Windows) CI runner, so the default 5s timeout is occasionally exceeded
+jest.setTimeout(15000);
+
 describe("commandExists()", () => {
 	test("should return `true` for existing command", async () => {
-		await expect(commandExists("cat")).resolves.toEqual(true);
+		// `cat` is not guaranteed to exist on Windows; `cmd` (the command interpreter) always is
+		const existingCommand = process.platform === "win32" ? "cmd" : "cat";
+		await expect(commandExists(existingCommand)).resolves.toEqual(true);
 	});
 
 	test("should return `false` for non-existent command", async () => {


### PR DESCRIPTION
Supersedes #216 (credited via `Co-authored-by`).

## Two fixes for the same test

**1. `cat` is not guaranteed on Windows** (the point of #216): `command-exists` checks a real command, and `cat` only exists on Windows if something like Git Bash is on PATH. Check for `cmd` (the command interpreter, always present) on Windows instead.

**2. Flakiness:** `command-exists` shells out to `where` (Windows) / `command -v` (Unix). Spawning that subprocess can occasionally exceed Jest's default 5s timeout on a loaded runner — this caused an intermittent `commandExists("cat")` timeout in CI (e.g. a Windows job on #1005 that needed a re-run). Two mitigations:
- `where cmd` resolves faster than `where cat` (`cmd.exe` is in `System32`, early on PATH, so `where` stops at the first directory).
- The suite's timeout is raised to 15s so subprocess-spawn latency under load no longer fails the test.

Test-only change; `dist/` is unaffected. Verified locally (lint, format, both tests pass).

https://claude.ai/code/session_01Juz45nWDAFudLx8dYBHc73