### PR TITLE
Re-enable the swift-format (official) linter tests on macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,7 +179,7 @@ jobs:
         run: |
           export HOMEBREW_NO_INSTALL_CLEANUP=1
           export HOMEBREW_NO_AUTO_UPDATE=1
-          brew install mint
+          brew install mint swift-format
           cd ./test/linters/projects/swift-format-lockwood/
           mint bootstrap --link --overwrite=y
           cd ../swiftlint/

--- a/dist/index.js
+++ b/dist/index.js
@@ -37706,6 +37706,8 @@ module.exports = SwiftFormatLockwood;
 /***/ 216:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
+const { sep } = __nccwpck_require__(6928);
+
 const { run } = __nccwpck_require__(8597);
 const commandExists = __nccwpck_require__(6339);
 const { initLintResult } = __nccwpck_require__(5066);
@@ -37749,9 +37751,11 @@ class SwiftFormatOfficial {
 		}
 
 		const mode = fix ? "format -i" : "lint";
+		// swift-format prints its findings to stderr and exits with 0, so stderr must be captured
 		return run(`${prefix} swift-format ${mode} ${args} --recursive "."`, {
 			dir,
 			ignoreErrors: true,
+			captureStderr: true,
 		});
 	}
 
@@ -37768,7 +37772,14 @@ class SwiftFormatOfficial {
 		const matches = output.stderr.matchAll(PARSE_REGEX);
 		for (const match of matches) {
 			const [_line, pathFull, line, _column, _level, message] = match;
-			const path = pathFull.substring(dir.length + 1);
+			// swift-format reports paths relative to the working directory, older versions used
+			// absolute paths — handle both
+			let path = pathFull;
+			if (path.startsWith(`${dir}${sep}`)) {
+				path = path.substring(dir.length + 1);
+			} else if (path.startsWith(`.${sep}`)) {
+				path = path.substring(2);
+			}
 			const lineNr = parseInt(line, 10);
 			// swift-format only seems to use the "warning" level, which this action will therefore
 			// categorize as errors
@@ -38050,11 +38061,11 @@ module.exports = XO;
 /***/ 8597:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const { execSync } = __nccwpck_require__(5317);
+const { execSync, spawnSync } = __nccwpck_require__(5317);
 
 const core = __nccwpck_require__(7484);
 
-const RUN_OPTIONS_DEFAULTS = { dir: null, ignoreErrors: false, prefix: "" };
+const RUN_OPTIONS_DEFAULTS = { dir: null, ignoreErrors: false, prefix: "", captureStderr: false };
 
 /**
  * Returns the value for an environment variable. If the variable is required but doesn't have a
@@ -38080,7 +38091,7 @@ function getEnv(name, required = false) {
 /**
  * Executes the provided shell command
  * @param {string} cmd - Shell command to execute
- * @param {{dir: string, ignoreErrors: boolean}} [options] - {@link RUN_OPTIONS_DEFAULTS}
+ * @param {object} [options] - Command options, see {@link RUN_OPTIONS_DEFAULTS}
  * @returns {{status: number, stdout: string, stderr: string}} - Output of the shell command
  */
 function run(cmd, options) {
@@ -38090,6 +38101,33 @@ function run(cmd, options) {
 	};
 
 	core.debug(cmd);
+
+	if (optionsWithDefaults.captureStderr) {
+		// `execSync` only exposes stderr when the command exits with a non-zero code. Some linters
+		// (e.g. swift-format) print their findings to stderr yet exit with 0, so `spawnSync` is used to
+		// capture stderr regardless of the exit code
+		const result = spawnSync(cmd, {
+			shell: true,
+			encoding: "utf8",
+			cwd: optionsWithDefaults.dir,
+			maxBuffer: 20 * 1024 * 1024,
+		});
+		if (result.error) {
+			throw result.error;
+		}
+		const output = {
+			status: result.status,
+			stdout: (result.stdout || "").trim(),
+			stderr: (result.stderr || "").trim(),
+		};
+		if (output.status !== 0 && !optionsWithDefaults.ignoreErrors) {
+			throw new Error(output.stderr || `Command failed with exit code ${output.status}`);
+		}
+		core.debug(`Exit code: ${output.status}`);
+		core.debug(`Stdout: ${output.stdout}`);
+		core.debug(`Stderr: ${output.stderr}`);
+		return output;
+	}
 
 	try {
 		const stdout = execSync(cmd, {

--- a/src/linters/swift-format-official.js
+++ b/src/linters/swift-format-official.js
@@ -1,3 +1,5 @@
+const { sep } = require("path");
+
 const { run } = require("../utils/action");
 const commandExists = require("../utils/command-exists");
 const { initLintResult } = require("../utils/lint-result");
@@ -41,9 +43,11 @@ class SwiftFormatOfficial {
 		}
 
 		const mode = fix ? "format -i" : "lint";
+		// swift-format prints its findings to stderr and exits with 0, so stderr must be captured
 		return run(`${prefix} swift-format ${mode} ${args} --recursive "."`, {
 			dir,
 			ignoreErrors: true,
+			captureStderr: true,
 		});
 	}
 
@@ -60,7 +64,14 @@ class SwiftFormatOfficial {
 		const matches = output.stderr.matchAll(PARSE_REGEX);
 		for (const match of matches) {
 			const [_line, pathFull, line, _column, _level, message] = match;
-			const path = pathFull.substring(dir.length + 1);
+			// swift-format reports paths relative to the working directory, older versions used
+			// absolute paths — handle both
+			let path = pathFull;
+			if (path.startsWith(`${dir}${sep}`)) {
+				path = path.substring(dir.length + 1);
+			} else if (path.startsWith(`.${sep}`)) {
+				path = path.substring(2);
+			}
 			const lineNr = parseInt(line, 10);
 			// swift-format only seems to use the "warning" level, which this action will therefore
 			// categorize as errors

--- a/src/utils/action.js
+++ b/src/utils/action.js
@@ -1,8 +1,8 @@
-const { execSync } = require("child_process");
+const { execSync, spawnSync } = require("child_process");
 
 const core = require("@actions/core");
 
-const RUN_OPTIONS_DEFAULTS = { dir: null, ignoreErrors: false, prefix: "" };
+const RUN_OPTIONS_DEFAULTS = { dir: null, ignoreErrors: false, prefix: "", captureStderr: false };
 
 /**
  * Returns the value for an environment variable. If the variable is required but doesn't have a
@@ -28,7 +28,7 @@ function getEnv(name, required = false) {
 /**
  * Executes the provided shell command
  * @param {string} cmd - Shell command to execute
- * @param {{dir: string, ignoreErrors: boolean}} [options] - {@link RUN_OPTIONS_DEFAULTS}
+ * @param {object} [options] - Command options, see {@link RUN_OPTIONS_DEFAULTS}
  * @returns {{status: number, stdout: string, stderr: string}} - Output of the shell command
  */
 function run(cmd, options) {
@@ -38,6 +38,33 @@ function run(cmd, options) {
 	};
 
 	core.debug(cmd);
+
+	if (optionsWithDefaults.captureStderr) {
+		// `execSync` only exposes stderr when the command exits with a non-zero code. Some linters
+		// (e.g. swift-format) print their findings to stderr yet exit with 0, so `spawnSync` is used to
+		// capture stderr regardless of the exit code
+		const result = spawnSync(cmd, {
+			shell: true,
+			encoding: "utf8",
+			cwd: optionsWithDefaults.dir,
+			maxBuffer: 20 * 1024 * 1024,
+		});
+		if (result.error) {
+			throw result.error;
+		}
+		const output = {
+			status: result.status,
+			stdout: (result.stdout || "").trim(),
+			stderr: (result.stderr || "").trim(),
+		};
+		if (output.status !== 0 && !optionsWithDefaults.ignoreErrors) {
+			throw new Error(output.stderr || `Command failed with exit code ${output.status}`);
+		}
+		core.debug(`Exit code: ${output.status}`);
+		core.debug(`Stdout: ${output.stdout}`);
+		core.debug(`Stderr: ${output.stderr}`);
+		return output;
+	}
 
 	try {
 		const stdout = execSync(cmd, {

--- a/test/linters/linters.test.js
+++ b/test/linters/linters.test.js
@@ -26,7 +26,7 @@ const standardrbParams = require("./params/standardrb");
 const staticcheckParams = require("./params/staticcheck");
 const stylelintParams = require("./params/stylelint");
 const swiftFormatLockwood = require("./params/swift-format-lockwood");
-// const swiftFormatOfficial = require("./params/swift-format-official");
+const swiftFormatOfficial = require("./params/swift-format-official");
 const swiftlintParams = require("./params/swiftlint");
 const tscParams = require("./params/tsc");
 const xoParams = require("./params/xo");
@@ -57,13 +57,8 @@ const linterParams = [
 	tscParams,
 	xoParams,
 ];
-if (process.platform === "linux") {
-	// Temporarily disabled because swift-format 0.50300.0 no longer returns a proper exit code, yet
-	// returns the errors in STDERR.
-	// linterParams.push(swiftFormatOfficial);
-}
 if (process.platform === "darwin") {
-	linterParams.push(swiftFormatLockwood, swiftlintParams);
+	linterParams.push(swiftFormatLockwood, swiftFormatOfficial, swiftlintParams);
 }
 
 const tmpDir = createTmpDir();

--- a/test/linters/params/swift-format-official.js
+++ b/test/linters/params/swift-format-official.js
@@ -1,5 +1,3 @@
-const { join } = require("path");
-
 const SwiftFormatOfficial = require("../../../src/linters/swift-format-official");
 
 const testName = "swift-format-official";
@@ -9,26 +7,22 @@ const commandPrefix = "";
 const extensions = ["swift"];
 
 function getLintParams(dir) {
-	const warning1 = `${join(dir, "file2.swift")}:2:22: warning: [DoNotUseSemicolons]: remove ';'`;
-	const warning2 = `${join(dir, "file1.swift")}:3:35: warning: [RemoveLine]: remove line break`;
-	const warning3 = `${join(
-		dir,
-		"file1.swift",
-	)}:7:1: warning: [Indentation] replace leading whitespace with 2 spaces`;
-	const warning4 = `${join(dir, "file1.swift")}:7:23: warning: [Spacing]: add 1 space`;
-	// Files on macOS are not sorted.
-	const stderr =
-		process.platform === "darwin"
-			? `${warning2}\n${warning3}\n${warning4}\n${warning1}`
-			: `${warning1}\n${warning2}\n${warning3}\n${warning4}`;
+	// swift-format reports its findings on stderr, with paths relative to the working directory
+	const warning1 = "file2.swift:2:22: warning: [DoNotUseSemicolons] remove ';'";
+	const warning2 = "file1.swift:3:35: warning: [RemoveLine] remove line break";
+	const warning3 =
+		"file1.swift:7:1: warning: [Indentation] replace leading whitespace with 2 spaces";
+	const warning4 = "file1.swift:7:23: warning: [Spacing] add 1 space";
 	return {
-		// Expected output of the linting function.
+		// Expected output of the linting function. swift-format exits with 0 even when there are
+		// findings, so only stderr is checked; the ordering can differ between platforms, hence
+		// stderrParts (substring matching) rather than an exact comparison
 		cmdOutput: {
 			status: 0,
 			stderrParts: [warning1, warning2, warning3, warning4],
-			stderr,
+			stderr: `${warning1}\n${warning2}\n${warning3}\n${warning4}`,
 		},
-		// Expected output of the parsing function.
+		// Expected output of the parsing function
 		lintResult: {
 			isSuccess: false,
 			error: [
@@ -36,13 +30,13 @@ function getLintParams(dir) {
 					path: "file2.swift",
 					firstLine: 2,
 					lastLine: 2,
-					message: "[DoNotUseSemicolons]: remove ';'",
+					message: "[DoNotUseSemicolons] remove ';'",
 				},
 				{
 					path: "file1.swift",
 					firstLine: 3,
 					lastLine: 3,
-					message: "[RemoveLine]: remove line break",
+					message: "[RemoveLine] remove line break",
 				},
 				{
 					path: "file1.swift",
@@ -54,7 +48,7 @@ function getLintParams(dir) {
 					path: "file1.swift",
 					firstLine: 7,
 					lastLine: 7,
-					message: "[Spacing]: add 1 space",
+					message: "[Spacing] add 1 space",
 				},
 			],
 			warning: [],
@@ -64,12 +58,12 @@ function getLintParams(dir) {
 
 function getFixParams(dir) {
 	return {
-		// Expected output of the linting function.
+		// Expected output of the linting function
 		cmdOutput: {
 			status: 0,
 			stderr: "",
 		},
-		// Expected output of the parsing function.
+		// Expected output of the parsing function
 		lintResult: {
 			isSuccess: true,
 			warning: [],


### PR DESCRIPTION
The `swift-format` (official Apple) linter tests were disabled ("Temporarily disabled because swift-format … returns the errors in STDERR"). swift-format is still a supported linter (`swift_format_official` in `action.yml`), so it was shipping untested. This re-enables it on macOS.

## Root cause

The disable comment named the symptom (stderr + exit 0) but the real blocker was in `run()`: `execSync` only exposes stderr when the command exits **non-zero**. swift-format prints its findings to stderr and exits **0**, so the runner (which reads `output.stderr`) always saw an empty string and reported success.

Fix: an opt-in `captureStderr` option on `run()`, backed by `spawnSync`, which captures stderr regardless of the exit code. It's opt-in (default off) so no other linter's behavior changes — in particular the swift-format-lockwood fix golden that expects `stderr: ""` is untouched.

## Output drift (swift-format 603 vs the old 509)

- Paths are now **relative** to the working directory (were absolute) — the runner's path stripping is updated to handle both.
- The message format dropped the colon after the rule name: `[Rule]: message` → `[Rule] message`. Golden updated.

This also makes the earlier #215 (slash-normalizing the absolute paths) unnecessary, since there is no directory prefix to normalize anymore.

## CI

`brew install swift-format` is added to the macOS Swift setup step. Verified locally against **swift-format 603.0.0**: all 4 swift-format-official tests pass, and the neighboring swift/non-linter suites stay green.

## Not in this PR

- **Linux**: needs a Swift toolchain that exposes a `swift-format` binary on PATH (Swift 6 bundles it, but as the `swift format` subcommand; whether `swift-format` is on PATH via a setup action needs CI iteration). Left as a follow-up.
- **Windows** (#213/#218): a separate, heavier effort (installing the Swift toolchain on the Windows runner).
