### PR TITLE
Test swift-format (official) on Linux too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,28 +142,18 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      # Swift (only on Linux)
+      # Swift (only on Linux). The toolchain bundles swift-format (matching the version installed via
+      # Homebrew on macOS), so no separate build is needed
 
-      - name: Set up Swift cache (Linux)
-        id: cache-swift
+      - name: Set up Swift (Linux)
         if: startsWith(matrix.os, 'ubuntu')
-        uses: actions/cache@v6
+        uses: SwiftyLab/setup-swift@v1
         with:
-          path: ./swift-format/.build
-          key: ${{ runner.os }}-swift-509.0.0
+          swift-version: "6.3.0"
 
-      - name: Install Swift dependencies (Linux, uncached)
-        if: steps.cache-swift.outputs.cache-hit != 'true' && startsWith(matrix.os, 'ubuntu')
-        run: |
-          git clone --branch 509.0.0 --depth 1 https://github.com/apple/swift-format
-          cd swift-format
-          swift build -c release
-          echo "${PWD}/.build/release" >> $GITHUB_PATH
-
-      - name: Install Swift dependencies (Linux, cached)
-        if: steps.cache-swift.outputs.cache-hit == 'true' && startsWith(matrix.os, 'ubuntu')
-        run: |
-          echo "${PWD}/swift-format/.build/release" >> $GITHUB_PATH
+      - name: Verify swift-format is available (Linux)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: swift-format --version
 
       # Swift (only on macOS)
 

--- a/test/linters/linters.test.js
+++ b/test/linters/linters.test.js
@@ -57,6 +57,9 @@ const linterParams = [
 	tscParams,
 	xoParams,
 ];
+if (process.platform === "linux") {
+	linterParams.push(swiftFormatOfficial);
+}
 if (process.platform === "darwin") {
 	linterParams.push(swiftFormatLockwood, swiftFormatOfficial, swiftlintParams);
 }


### PR DESCRIPTION
Follow-up to #1009, which re-enabled the swift-format (official) tests on macOS. This adds Linux.

## Change

The old setup built swift-format 509 from source (a slow step that in practice only ever restored from cache). Since Swift 6 bundles swift-format in the toolchain, this replaces the from-source build with the `SwiftyLab/setup-swift` action pinned to Swift 6.3 — the same swift-format version Homebrew installs on macOS, so the golden output matches on both platforms. The `swift-format-official` tests are enabled on Linux.

## Note

This is a CI-only change that can't be verified locally (no Linux runner here), so it may need a round or two of iteration. The two things being confirmed by CI:

1. `SwiftyLab/setup-swift` puts a `swift-format` binary on PATH on Ubuntu (there's an explicit `swift-format --version` verify step for a fast, clear signal).
2. The Linux swift-format 6.3 output matches the golden established from swift-format 603.0.0 on macOS.

If either doesn't hold, the fix is contained to the workflow / this linter's params.
