### PR TITLE
Test swift-format (official) on Windows too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,6 +155,18 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: swift-format --version
 
+      # Swift (only on Windows). Same approach as Linux — the toolchain bundles swift-format
+
+      - name: Set up Swift (Windows)
+        if: startsWith(matrix.os, 'windows')
+        uses: SwiftyLab/setup-swift@v1
+        with:
+          swift-version: "6.3.0"
+
+      - name: Verify swift-format is available (Windows)
+        if: startsWith(matrix.os, 'windows')
+        run: swift-format --version
+
       # Swift (only on macOS)
 
       - name: Set up Mint cache (macOS)

--- a/test/linters/linters.test.js
+++ b/test/linters/linters.test.js
@@ -57,7 +57,7 @@ const linterParams = [
 	tscParams,
 	xoParams,
 ];
-if (process.platform === "linux") {
+if (process.platform === "linux" || process.platform === "win32") {
 	linterParams.push(swiftFormatOfficial);
 }
 if (process.platform === "darwin") {

--- a/test/linters/linters.test.js
+++ b/test/linters/linters.test.js
@@ -54,14 +54,13 @@ const linterParams = [
 	standardrbParams,
 	staticcheckParams,
 	stylelintParams,
+	swiftFormatOfficial,
 	tscParams,
 	xoParams,
 ];
-if (process.platform === "linux" || process.platform === "win32") {
-	linterParams.push(swiftFormatOfficial);
-}
+// swift-format-lockwood and SwiftLint are installed via Mint on macOS only
 if (process.platform === "darwin") {
-	linterParams.push(swiftFormatLockwood, swiftFormatOfficial, swiftlintParams);
+	linterParams.push(swiftFormatLockwood, swiftlintParams);
 }
 
 const tmpDir = createTmpDir();

--- a/test/linters/projects/swift-format-official/.gitattributes
+++ b/test/linters/projects/swift-format-official/.gitattributes
@@ -1,0 +1,3 @@
+# swift-format columns/offsets depend on the file content; keep LF so the golden matches on
+# Windows too (avoids autocrlf converting the fixtures to CRLF on checkout)
+*.swift text eol=lf


### PR DESCRIPTION
Follow-up to #1009 (macOS) and #1010 (Linux). This attempts Windows.

## Change

- Install the Swift 6.3 toolchain on Windows via `SwiftyLab/setup-swift` (it advertises Linux/macOS/Windows support), which bundles `swift-format` — the same version already used on macOS and Linux, so the golden should match.
- Enable the `swift-format-official` tests on Windows, with a `swift-format --version` verify step for a fast, clear signal.
- Add a `.gitattributes` pinning the `.swift` fixtures to LF, so `autocrlf` on the Windows runner doesn't change the file content the golden is based on.

## Note

CI-only, can't be verified locally (no Windows runner here) — may need iteration. What CI confirms:

1. `SwiftyLab/setup-swift` puts `swift-format` on PATH on Windows (verify step).
2. The Windows swift-format 6.3 output (paths, message format, ordering) matches the golden.

If the paths come through with backslashes or the toolchain doesn't expose `swift-format`, the fix is contained to this linter's runner/params and the workflow.
