### PR TITLE
Make annotation paths repo-root-relative and use forward slashes

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -38280,9 +38280,34 @@ function getSummary(lintResult) {
 	return `no issues`;
 }
 
+/**
+ * Rewrites the paths of a lint result so GitHub can link the annotations to the files of a pull
+ * request: the paths are made relative to the repository root (by prepending the directory the
+ * linter ran in) and are converted to forward slashes. GitHub's Checks API only matches annotations
+ * to the diff when the paths are repo-root-relative and use forward slashes (see #94 and #608)
+ * @param {LintResult} lintResult - Lint result whose paths should be rewritten (mutated in place)
+ * @param {string} dirRel - Directory the linter ran in, relative to the repository root
+ * @returns {LintResult} - The same lint result, with rewritten paths
+ */
+function normalizeLintResultPaths(lintResult, dirRel) {
+	// Strip a leading "./" and any trailing slash, and use forward slashes
+	const dir =
+		dirRel && dirRel !== "."
+			? dirRel.replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/+$/, "")
+			: "";
+	for (const level of ["error", "warning"]) {
+		for (const entry of lintResult[level]) {
+			const path = entry.path.replace(/\\/g, "/");
+			entry.path = dir ? `${dir}/${path}` : path;
+		}
+	}
+	return lintResult;
+}
+
 module.exports = {
 	getSummary,
 	initLintResult,
+	normalizeLintResultPaths,
 };
 
 
@@ -40372,7 +40397,7 @@ const git = __nccwpck_require__(5661);
 const { createCheck } = __nccwpck_require__(2257);
 const { getContext } = __nccwpck_require__(4022);
 const linters = __nccwpck_require__(7065);
-const { getSummary } = __nccwpck_require__(5066);
+const { getSummary, normalizeLintResultPaths } = __nccwpck_require__(5066);
 
 /**
  * Parses the action configuration and runs all enabled linters on matching files
@@ -40458,8 +40483,11 @@ async function runAction() {
 			);
 			const lintOutput = linter.lint(lintDirAbs, fileExtList, args, linterAutoFix, prefix);
 
-			// Parse output of linting command
-			const lintResult = linter.parseOutput(context.workspace, lintOutput);
+			// Parse output of linting command. The linter ran in `lintDirAbs`, so its output paths are
+			// relative to that directory; make them relative to the repository root (with forward
+			// slashes) so GitHub can link the annotations to the pull request's files
+			const lintResult = linter.parseOutput(lintDirAbs, lintOutput);
+			normalizeLintResultPaths(lintResult, lintDirRel);
 			const summary = getSummary(lintResult);
 			core.info(
 				`${linter.name} found ${summary} (${lintResult.isSuccess ? "success" : "failure"})`,

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const git = require("./git");
 const { createCheck } = require("./github/api");
 const { getContext } = require("./github/context");
 const linters = require("./linters");
-const { getSummary } = require("./utils/lint-result");
+const { getSummary, normalizeLintResultPaths } = require("./utils/lint-result");
 
 /**
  * Parses the action configuration and runs all enabled linters on matching files
@@ -93,8 +93,11 @@ async function runAction() {
 			);
 			const lintOutput = linter.lint(lintDirAbs, fileExtList, args, linterAutoFix, prefix);
 
-			// Parse output of linting command
-			const lintResult = linter.parseOutput(context.workspace, lintOutput);
+			// Parse output of linting command. The linter ran in `lintDirAbs`, so its output paths are
+			// relative to that directory; make them relative to the repository root (with forward
+			// slashes) so GitHub can link the annotations to the pull request's files
+			const lintResult = linter.parseOutput(lintDirAbs, lintOutput);
+			normalizeLintResultPaths(lintResult, lintDirRel);
 			const summary = getSummary(lintResult);
 			core.info(
 				`${linter.name} found ${summary} (${lintResult.isSuccess ? "success" : "failure"})`,

--- a/src/utils/lint-result.js
+++ b/src/utils/lint-result.js
@@ -42,7 +42,32 @@ function getSummary(lintResult) {
 	return `no issues`;
 }
 
+/**
+ * Rewrites the paths of a lint result so GitHub can link the annotations to the files of a pull
+ * request: the paths are made relative to the repository root (by prepending the directory the
+ * linter ran in) and are converted to forward slashes. GitHub's Checks API only matches annotations
+ * to the diff when the paths are repo-root-relative and use forward slashes (see #94 and #608)
+ * @param {LintResult} lintResult - Lint result whose paths should be rewritten (mutated in place)
+ * @param {string} dirRel - Directory the linter ran in, relative to the repository root
+ * @returns {LintResult} - The same lint result, with rewritten paths
+ */
+function normalizeLintResultPaths(lintResult, dirRel) {
+	// Strip a leading "./" and any trailing slash, and use forward slashes
+	const dir =
+		dirRel && dirRel !== "."
+			? dirRel.replace(/\\/g, "/").replace(/^\.\//, "").replace(/\/+$/, "")
+			: "";
+	for (const level of ["error", "warning"]) {
+		for (const entry of lintResult[level]) {
+			const path = entry.path.replace(/\\/g, "/");
+			entry.path = dir ? `${dir}/${path}` : path;
+		}
+	}
+	return lintResult;
+}
+
 module.exports = {
 	getSummary,
 	initLintResult,
+	normalizeLintResultPaths,
 };

--- a/test/utils/lint-result.test.js
+++ b/test/utils/lint-result.test.js
@@ -1,0 +1,59 @@
+const { normalizeLintResultPaths } = require("../../src/utils/lint-result");
+
+/**
+ * Builds a lint result with the given error and warning paths
+ * @param {string[]} errorPaths - Paths for the error entries
+ * @param {string[]} warningPaths - Paths for the warning entries
+ * @returns {object} - Lint result
+ */
+function lintResult(errorPaths, warningPaths = []) {
+	const toEntry = (path) => ({ path, firstLine: 1, lastLine: 1, message: "msg" });
+	return {
+		isSuccess: false,
+		error: errorPaths.map(toEntry),
+		warning: warningPaths.map(toEntry),
+	};
+}
+
+describe("normalizeLintResultPaths()", () => {
+	test("leaves repo-root paths unchanged when the linter runs in the root", () => {
+		const result = normalizeLintResultPaths(lintResult(["file.py"]), ".");
+		expect(result.error[0].path).toEqual("file.py");
+	});
+
+	test("prepends the linter directory so paths are relative to the repository root (#94)", () => {
+		const result = normalizeLintResultPaths(lintResult(["file.py"]), "subdir");
+		expect(result.error[0].path).toEqual("subdir/file.py");
+	});
+
+	test("handles nested linter directories", () => {
+		const result = normalizeLintResultPaths(lintResult(["a/file.py"]), "src/app");
+		expect(result.error[0].path).toEqual("src/app/a/file.py");
+	});
+
+	test("converts backslash paths to forward slashes (#608)", () => {
+		const result = normalizeLintResultPaths(lintResult(["sub\\file.cs"]), ".");
+		expect(result.error[0].path).toEqual("sub/file.cs");
+	});
+
+	test("combines the directory prefix and slash conversion", () => {
+		const result = normalizeLintResultPaths(lintResult(["sub\\file.cs"]), "src\\app");
+		expect(result.error[0].path).toEqual("src/app/sub/file.cs");
+	});
+
+	test("does not produce double slashes for a directory with a trailing slash", () => {
+		const result = normalizeLintResultPaths(lintResult(["file.py"]), "subdir/");
+		expect(result.error[0].path).toEqual("subdir/file.py");
+	});
+
+	test("strips a leading ./ from the directory", () => {
+		const result = normalizeLintResultPaths(lintResult(["file.py"]), "./subdir");
+		expect(result.error[0].path).toEqual("subdir/file.py");
+	});
+
+	test("rewrites both error and warning paths", () => {
+		const result = normalizeLintResultPaths(lintResult(["e.py"], ["w.py"]), "dir");
+		expect(result.error[0].path).toEqual("dir/e.py");
+		expect(result.warning[0].path).toEqual("dir/w.py");
+	});
+});


### PR DESCRIPTION
GitHub only links check-run annotations to the files of a pull request when their paths are **relative to the repository root** and use **forward slashes**. Two long-standing issues stem from paths that don't meet this:

## Fixes

**#94 — annotations don't work with `[linter]_dir`.** When a linter runs in a subdirectory, its output paths are relative to that subdirectory, so the annotations point at the wrong location and don't show up on the Files tab. Two parts:
- `parseOutput` is now called with the directory the linter actually ran in (`lintDirAbs`) instead of the workspace root, so its path stripping is correct.
- The linter directory is then prepended, making the paths repo-root-relative.

**#608 — dotnet-format annotations missing on Windows.** dotnet-format emits backslash paths on Windows; these are now converted to forward slashes.

Both are handled centrally by a new `normalizeLintResultPaths(lintResult, dirRel)` helper, so every linter benefits (not just the ones reported).

## Tests

New `test/utils/lint-result.test.js` covers the helper: directory prefixing (incl. nested and trailing-slash), backslash→slash conversion, the combination, and both error and warning paths. The `.` (root) case is a no-op apart from slash conversion, so the common setup is unaffected. `dist/` is rebuilt.


Fixes #94.
Fixes #608.