### PR TITLE
Prepare v3.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ jobs:
       # Install your linters here
 
       - name: Run linters
-        uses: wearerequired/lint-action@v2
+        uses: wearerequired/lint-action@v3
         with:
           # Enable your linters here
 ```
@@ -146,7 +146,7 @@ jobs:
         run: npm ci
 
       - name: Run linters
-        uses: wearerequired/lint-action@v2
+        uses: wearerequired/lint-action@v3
         with:
           eslint: true
           prettier: true
@@ -186,7 +186,7 @@ jobs:
           tools: phpcs
 
       - name: Run linters
-        uses: wearerequired/lint-action@v2
+        uses: wearerequired/lint-action@v3
         with:
           php_codesniffer: true
           # Optional: Ignore warnings
@@ -230,7 +230,7 @@ jobs:
           echo "${PWD}/vendor/bin" >> $GITHUB_PATH
 
       - name: Run linters
-        uses: wearerequired/lint-action@v2
+        uses: wearerequired/lint-action@v3
         with:
           php_codesniffer: true
 ```
@@ -268,7 +268,7 @@ jobs:
         run: pip install black flake8
 
       - name: Run linters
-        uses: wearerequired/lint-action@v2
+        uses: wearerequired/lint-action@v3
         with:
           black: true
           flake8: true
@@ -302,7 +302,7 @@ jobs:
         run: sudo apt-get install -y clang-format
 
       - name: Run linters
-        uses: wearerequired/lint-action@v2
+        uses: wearerequired/lint-action@v3
         with:
           clang_format: true
 ```
@@ -337,7 +337,7 @@ jobs:
           dotnet-version: "6.0.x"
 
       - name: Run linters
-        uses: wearerequired/lint-action@v2
+        uses: wearerequired/lint-action@v3
         with:
           dotnet_format: true
 ```
@@ -375,7 +375,7 @@ jobs:
         run: pip install black flake8
 
       - name: Run linters
-        uses: wearerequired/lint-action@v2
+        uses: wearerequired/lint-action@v3
         with:
           auto_fix: true
           black: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lint-action",
-	"version": "2.3.0",
+	"version": "3.0.0",
 	"description": "GitHub Action for detecting and fixing linting errors",
 	"repository": "github:wearerequired/lint-action",
 	"license": "MIT",


### PR DESCRIPTION
Bumps the version to 3.0.0 and updates the README usage examples to `wearerequired/lint-action@v3` ahead of the v3.0.0 release. Merge together with publishing the v3.0.0 release so the examples resolve to an existing tag.