### PR TITLE
Fix auto-fix crash when tracked files are only stat-dirty

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -35219,6 +35219,13 @@ function getHeadSha() {
  * @returns {boolean} - Boolean indicating whether changes exist
  */
 function hasChanges() {
+	// Refresh the index first so stat-only differences are not mistaken for real changes. A
+	// dependency install step or a formatter can rewrite a tracked file with identical content,
+	// leaving it stat-dirty. Without the refresh, `git diff-index` reports such a file as modified
+	// while the subsequent `git commit -am` finds nothing to commit and exits non-zero, which
+	// crashes the action (#140). `git update-index --refresh` exits non-zero when it updates stat
+	// info, so its errors are ignored.
+	run("git update-index -q --refresh", { ignoreErrors: true });
 	const output = run("git diff-index --name-status --exit-code HEAD --", { ignoreErrors: true });
 	const hasChangedFiles = output.status === 1;
 	core.info(`${hasChangedFiles ? "Changes" : "No changes"} found with Git`);

--- a/src/git.js
+++ b/src/git.js
@@ -69,6 +69,13 @@ function getHeadSha() {
  * @returns {boolean} - Boolean indicating whether changes exist
  */
 function hasChanges() {
+	// Refresh the index first so stat-only differences are not mistaken for real changes. A
+	// dependency install step or a formatter can rewrite a tracked file with identical content,
+	// leaving it stat-dirty. Without the refresh, `git diff-index` reports such a file as modified
+	// while the subsequent `git commit -am` finds nothing to commit and exits non-zero, which
+	// crashes the action (#140). `git update-index --refresh` exits non-zero when it updates stat
+	// info, so its errors are ignored.
+	run("git update-index -q --refresh", { ignoreErrors: true });
 	const output = run("git diff-index --name-status --exit-code HEAD --", { ignoreErrors: true });
 	const hasChangedFiles = output.status === 1;
 	core.info(`${hasChangedFiles ? "Changes" : "No changes"} found with Git`);

--- a/test/git-has-changes.test.js
+++ b/test/git-has-changes.test.js
@@ -1,0 +1,59 @@
+const { execSync } = require("child_process");
+const { mkdtempSync, writeFileSync, utimesSync, rmSync } = require("fs");
+const { tmpdir } = require("os");
+const { join } = require("path");
+
+const git = require("../src/git");
+
+// These tests exercise `hasChanges` against a throwaway repository using the real `run` helper, so
+// `../src/utils/action` must not be mocked here (unlike git.test.js).
+describe("hasChanges", () => {
+	let repoDir;
+	let originalCwd;
+
+	/**
+	 * Runs a Git command inside the throwaway repository
+	 * @param {string} cmd - Git command to run
+	 */
+	function gitCmd(cmd) {
+		execSync(cmd, { cwd: repoDir, stdio: "ignore" });
+	}
+
+	beforeEach(() => {
+		originalCwd = process.cwd();
+		repoDir = mkdtempSync(join(tmpdir(), "lint-action-git-"));
+		gitCmd("git init");
+		gitCmd("git config user.email test@example.com");
+		gitCmd("git config user.name Test");
+		gitCmd("git config commit.gpgsign false");
+		writeFileSync(join(repoDir, "file.txt"), "content\n");
+		gitCmd("git add -A");
+		gitCmd("git commit -m init");
+		// `hasChanges` runs Git in the current working directory
+		process.chdir(repoDir);
+	});
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+		rmSync(repoDir, { recursive: true, force: true });
+	});
+
+	test("returns false when the working tree matches HEAD", () => {
+		expect(git.hasChanges()).toBe(false);
+	});
+
+	test("returns false when a tracked file is stat-dirty but unchanged (#140)", () => {
+		// A dependency install step or a formatter can rewrite a tracked file with identical content,
+		// leaving it stat-dirty. Before the index refresh this was reported as a change, and the
+		// subsequent `git commit -am` then crashed the action with "nothing to commit".
+		writeFileSync(join(repoDir, "file.txt"), "content\n");
+		const future = new Date(Date.now() + 60000);
+		utimesSync(join(repoDir, "file.txt"), future, future);
+		expect(git.hasChanges()).toBe(false);
+	});
+
+	test("returns true when a tracked file's content actually changes", () => {
+		writeFileSync(join(repoDir, "file.txt"), "changed\n");
+		expect(git.hasChanges()).toBe(true);
+	});
+});


### PR DESCRIPTION
Closes #140.

## Problem

With `auto_fix: true`, the action crashes with an unhandled rejection when it thinks there are changes but `git commit -am` has nothing to commit:

```
Committing changes
Error: Command failed: git commit -am "Fix code style issues with ESLint"
Error: Exiting because of unhandled promise rejection
```

`hasChanges()` used `git diff-index --exit-code HEAD` **without refreshing the index**. A tracked file rewritten with identical content — a lockfile touched by a `npm`/`yarn install` step, or a formatter that rewrites files without changing them — is left *stat-dirty*: `git diff-index` reports it as modified, but `git commit -am` compares content, finds nothing to commit, and exits non-zero. `commitChanges()` runs that with the default `ignoreErrors: false`, so it throws and the action dies.

The other historical trigger from the issue (only *untracked* files present) is already handled — `hasChanges()` correctly returns `false` there.

## Fix

Refresh the index with `git update-index -q --refresh` before diffing, so stat-only differences are no longer mistaken for real changes. `git update-index --refresh` exits non-zero when it updates stat info, so its errors are ignored.

Verified against a real repository:

| Working tree | before fix | after fix |
|---|---|---|
| clean | `false` | `false` |
| tracked file stat-dirty, identical content | **`true`** → commit crashes | `false` |
| tracked file content actually changed | `true` | `true` |

## Tests

Adds `test/git-has-changes.test.js` — a real-repo regression test covering all three cases above (the stat-dirty case reproduced #140 against the unpatched code).

No version bump: rides along in the still-unreleased v3.0.2.